### PR TITLE
fix: Windows build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,22 +28,7 @@ set(CMAKE_VERBOSE_MAKEFILE ON)
 
 if (WIN32)
 	# res/app.rc
-	SET(RESOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/res/app.rc
-			TestClass.cpp
-			TestClass.h
-			Shape.cpp
-			Shape.h
-			ShapeSphere.cpp
-			ShapeSphere.h
-			Body.cpp
-			Body.h
-			Intersections.cpp
-			Intersections.h
-			CWorld.cpp
-			CWorld.h
-			collision.cpp
-			collision.h
-	)
+	SET(RESOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/res/app.rc)
 endif()
 
 if (MSVC)
@@ -52,13 +37,10 @@ endif()
 
 add_subdirectory(dependencies/SDL2.28.4)
 
-
 # add_executable(Game
 # 	${SRC_FILES}
 # 	${HEADER_FILES}
 # )	
-
-
 
 add_executable(Game
 

--- a/game.cpp
+++ b/game.cpp
@@ -1,6 +1,7 @@
 #include "game.h"
 
 #include <SDL.h>
+#include <string>
 
 #include "r_itexture.h"
 #include "camera.h"
@@ -41,13 +42,19 @@ void Game::Init()
 	std::vector<TriPlane> worldTris{};
 	MapVersion mapVersion = VALVE_220; // TODO: Change to MAP_TYPE_QUAKE
 	
-	std::string mapData = loadTextFile(m_ExePath + "../assets/maps/room.map"); // TODO: Sane loading of Maps based on path
+    // TODO: Sane loading of Maps to be system independent ( see other resource loading ).
+#ifdef _WIN32
+	std::string mapData = loadTextFile(m_ExePath + "../../assets/maps/room.map"); 
+#elif __LINUX__
+    std::string mapData = loadTextFile(m_ExePath + "../assets/maps/room.map"); 
+#endif
+
 	size_t inputLength = mapData.length();
 	Map map = getMap(&mapData[0], inputLength, mapVersion);	
 	std::vector<MapPolygon> polysoup = createPolysoup(map);
 	std::vector<MapPolygon> tris = triangulate(polysoup);
 	
-	glm::vec4 triColor = glm::vec4( RandBetween(0.0f, 1.0f), RandBetween(0.0f, 1.0f), RandBetween(0.0f, 1.0f), 1.0f);
+	glm::vec4 triColor = glm::vec4( 0.1f, 0.8f, 1.0f, 1.0f );
 	for (int i = 0; i < tris.size(); i++) {
 		MapPolygon mapPoly = tris[ i ];
 		Vertex A = { glm::vec3(mapPoly.vertices[0].x, mapPoly.vertices[0].y, mapPoly.vertices[0].z) };

--- a/polysoup.cpp
+++ b/polysoup.cpp
@@ -26,7 +26,7 @@
 #define PS_FLOAT_EPSILON	(0.0001)
 
 
-static std::string loadTextFile(std::string file)
+std::string loadTextFile(std::string file)
 {
 	std::ifstream iFileStream;
 	std::stringstream ss;
@@ -42,7 +42,7 @@ static std::string loadTextFile(std::string file)
 	return data;
 }
 
-static void writePolys(std::string fileName, std::vector<MapPolygon> polys)
+void writePolys(std::string fileName, std::vector<MapPolygon> polys)
 {
 	std::ofstream oFileStream;
 	oFileStream.open(fileName, std::ios::binary | std::ios::out);
@@ -59,7 +59,7 @@ static void writePolys(std::string fileName, std::vector<MapPolygon> polys)
 	oFileStream.close();
 }
 
-static void writePolysOBJ(std::string fileName, std::vector<MapPolygon> polys)
+void writePolysOBJ(std::string fileName, std::vector<MapPolygon> polys)
 {
 	std::stringstream faces;
 	std::ofstream oFileStream;


### PR DESCRIPTION
- Amend `CMakeLists.txt` (largely a cleanup, add highest warning level)
- Remove statics from `polysoup.cpp`. It used to be a self-contained tool but now it is needed in other compilation units -> MSVC complains about this, understandably.
- Windows will build using MSVC, not clang. 
- There are resource files compiled into the executable. It is the image from an old project. Artists are welcome to change this to match our game :) 

@NicoB-Coding can you please try it out?