### PR TITLE
Fix: follow camera to face model direction

### DIFF
--- a/Entity/FollowCamera/g_follow_camera.cpp
+++ b/Entity/FollowCamera/g_follow_camera.cpp
@@ -7,27 +7,38 @@
 CFollowCamera::CFollowCamera(const int id, BaseGameEntity* target)
     : BaseGameEntity(id, ET_CAMERA) {
 
-	assert( target != nullptr );
+    assert( target != nullptr );
 
-	m_Target = target;
-	m_Position = target->m_Position;
-	m_Camera = Camera(m_Position);
+    m_Target = target;
+    m_Position = target->m_Position;
+    m_Camera = Camera(m_Position);
+    // FIX: The player model (target) was modeled to face to -y which
+    // is not the default! When we use actual models we should pay 
+    // attention to model our characters to face +y to not have to 
+    // do fixes in code.
+    m_RotationAngle = 180.0f; 
 }
 
 CFollowCamera::~CFollowCamera() {
 }
 
 void CFollowCamera::Update() {
-	glm::vec3 targetPos = m_Target->m_Position;
+    glm::vec3 targetPos = m_Target->m_Position;
+    float rotationAngle = m_Target->m_RotationAngle;
 
-	// Set this entitiy's position based on target entity.
+    //printf("rotationAngle: %f\n", rotationAngle);
+
+    m_Camera.SetOrientationFromAngle(m_RotationAngle + rotationAngle, glm::vec3(0.0f, 0.0f, 1.0f) );
+    //m_Camera.RotateAroundUp(rotationAngle);
+
+    // Set this entitiy's position based on target entity.
     m_Position.x = targetPos.x;
     m_Position.y = targetPos.y;
     m_Position.z = targetPos.z + 70.0f;
     m_Position += (-m_Camera.m_Forward * 80.0f);
 
-	// Set this entity's camera data
-	m_Camera.m_Pos = m_Position;
+    // Set this entity's camera data
+    m_Camera.m_Pos = m_Position;
 }
 
 bool CFollowCamera::HandleMessage(const Telegram& telegram) {
@@ -35,10 +46,10 @@ bool CFollowCamera::HandleMessage(const Telegram& telegram) {
 }
 
 void CFollowCamera::SetTarget(BaseGameEntity* target) {
-	assert( target != nullptr );
-	m_Target = target;
-	m_Position = target->m_Position;
-	m_Camera.m_Pos = m_Position;
-	printf("follow camera pos: %f, %f, %f\n", m_Position.x, m_Position.y, m_Position.z);
+    assert( target != nullptr );
+    m_Target = target;
+    m_Position = target->m_Position;
+    m_Camera.m_Pos = m_Position;
+    printf("follow camera pos: %f, %f, %f\n", m_Position.x, m_Position.y, m_Position.z);
 }
 

--- a/Entity/Player/g_player.cpp
+++ b/Entity/Player/g_player.cpp
@@ -97,6 +97,8 @@ void Player::UpdatePlayerModel() {
     ButtonState left = CHECK_ACTION("left");
     ButtonState right = CHECK_ACTION("right");
     ButtonState speed = CHECK_ACTION("speed");
+    ButtonState turnLeft = CHECK_ACTION("turn_left");
+    ButtonState turnRight = CHECK_ACTION("turn_right");
     
     double dt = GetDeltaTime();
     float followCamSpeed = 0.05f;
@@ -107,16 +109,23 @@ void Player::UpdatePlayerModel() {
     }
 
     // Model rotation
-    m_RotationAngle = followTurnSpeed * (float)dt;
-    if (KeyPressed(SDLK_RIGHT)) {
-        m_RotationAngle = -m_RotationAngle;
-        glm::quat rot = glm::angleAxis(glm::radians(m_RotationAngle), glm::vec3(0.0f, 0.0f, 1.0f));
-        m_Model.orientation *= rot;
+    if ( turnLeft == ButtonState::PRESSED ) {
+        m_RotationAngle += followTurnSpeed * (float)dt; // TODO: Should be a quaternion in base game entity.
     }
-    if (KeyPressed(SDLK_LEFT)) {
-        glm::quat rot = glm::angleAxis(glm::radians(m_RotationAngle), glm::vec3(0.0f, 0.0f, 1.0f));
-        m_Model.orientation *= rot;
+    if ( turnRight == ButtonState::PRESSED ) {
+        m_RotationAngle -= followTurnSpeed * (float)dt;
     }
+   
+    // TODO: If dealing with m_Orientation quaternion, this test can be omitted.
+    if (m_RotationAngle >= 360.0f) {
+        m_RotationAngle = 0.0f;
+    }
+    else if (m_RotationAngle < 0.0f) {
+        m_RotationAngle = 360.0f;
+    }
+
+    glm::quat rot = glm::angleAxis(glm::radians(m_RotationAngle), glm::vec3(0.0f, 0.0f, 1.0f));
+    m_Model.orientation = rot;
 
     m_Forward = glm::rotate(m_Model.orientation,
                             glm::vec3(0.0f, -1.0f, 0.0f)); // -1 because the model is facing -1 (Outside the screen)

--- a/Entity/Player/g_player.h
+++ b/Entity/Player/g_player.h
@@ -36,7 +36,6 @@ class Player : public BaseGameEntity, public IInputReceiver {
     void UpdatePlayerModel();
 
   public:
-    float m_RotationAngle;
     explicit Player(const int id, glm::vec3 initialPosition);
     ~Player() override {
         delete m_pStateMachine;

--- a/Entity/base_game_entity.h
+++ b/Entity/base_game_entity.h
@@ -61,7 +61,8 @@ public:
         return m_ID;
     }
     
-    glm::vec3  m_Position = glm::vec3(0.0f);
+    glm::vec3   m_Position = glm::vec3(0.0f);
+    float       m_RotationAngle = 0.0f; // TODO: Should be a quaternion called m_Orientation.
 };
 
 #endif // BASEGAMEENTITY_H

--- a/camera.cpp
+++ b/camera.cpp
@@ -39,8 +39,17 @@ void Camera::RotateAroundSide(float angle)
 	m_Orientation *= orientation;
 }
 
+void Camera::SetOrientationFromAngle(float angle, glm::vec3 axis) {
+	glm::quat orientation = glm::angleAxis( glm::radians(angle), axis );
+	m_Up = glm::rotate( orientation, glm::vec3(0.0f, 0.0f, 1.0f) );
+	m_Forward = glm::rotate( orientation, glm::vec3(0.0f, 1.0f, 0.0f) );
+	m_Side = glm::rotate( orientation, glm::vec3(1.0f, 0.0f, 0.0f) );
+	m_Orientation = orientation;
+}
+
 glm::mat4 Camera::ViewMatrix(void)
 {
 	glm::vec3 center = m_Pos + m_Forward;
 	return glm::lookAt(m_Pos, center, m_Up);
 }
+

--- a/camera.h
+++ b/camera.h
@@ -15,6 +15,7 @@ public:
 	void Rotate(glm::quat quat);
 	void RotateAroundUp(float angle);
 	void RotateAroundSide(float angle);
+	void SetOrientationFromAngle(float angle, glm::vec3 axis);
 
 	glm::mat4 ViewMatrix(void);
 

--- a/game.cpp
+++ b/game.cpp
@@ -152,7 +152,7 @@ void Game::Init() {
     m_pFlyCameraEntity = new CFlyCamera( idCounter++, glm::vec3(0.0f) );
   
     // FIX: If the follow camera is registered *before* one of the entities
-    // the follow camera will lage behind one frame because it won't
+    // the follow camera will lag behind one frame because it won't
     // get the most up to date position of its target!
     // We can choose to have a dedicated array for all of the
     // camera entity types and let the entity manager take care
@@ -162,7 +162,7 @@ void Game::Init() {
     m_pFollowCameraEntity->m_Camera.m_Pos.y -= 200.0f;
     m_pFollowCameraEntity->m_Camera.m_Pos.z += 100.0f;
     m_pFollowCameraEntity->m_Camera.RotateAroundSide(0.0f);
-    m_pFollowCameraEntity->m_Camera.RotateAroundUp(180.0f);
+    //m_pFollowCameraEntity->m_Camera.RotateAroundUp(180.0f);
     m_pEntityManager->RegisterEntity(m_pFollowCameraEntity);
    
     // Upload this model to the GPU. This will add the model to the model-batch and you get an ID where to find the data
@@ -184,6 +184,8 @@ void Game::Init() {
     inputHandler->BindInputToActionName(SDLK_d, "right");
     inputHandler->BindInputToActionName(SDLK_LSHIFT, "speed");
     inputHandler->BindInputToActionName(SDLK_c, "set_captain");
+    inputHandler->BindInputToActionName(SDLK_LEFT, "turn_left");
+    inputHandler->BindInputToActionName(SDLK_RIGHT, "turn_right");
     // Mouse buttons
     inputHandler->BindInputToActionName(SDL_BUTTON_LEFT, "fire"); 
     inputHandler->BindInputToActionName(SDL_BUTTON_RIGHT, "look"); 


### PR DESCRIPTION
By trying out the input system I set up a new entity, called the "Follow Camera". One can set the target entity and the follow camera just follow this entity.
The rotation was not performed correctly when the target entity rotates around. This is fixed with this PR.
Note that this is not final. For example, at the moment the Model itself stores a lot of state like the orientation. This really should be in the (Base) Entity. The model ist just... the model. It doesn't know about its position in world space or its orientation.

But I wanted to fix this before merging into main so the bahaviour is the same as we had before.
