### PR TITLE
fix: Render brushes from func_groups correctly

### DIFF
--- a/game.cpp
+++ b/game.cpp
@@ -57,7 +57,7 @@ void Game::Init() {
 #ifdef _WIN32
     std::string mapData = loadTextFile(m_ExePath + "../../assets/maps/enemy_test.map");
 #elif __LINUX__
-    std::string mapData = loadTextFile(m_ExePath + "../assets/maps/temple2.map");
+    std::string mapData = loadTextFile(m_ExePath + "../assets/maps/Prototype.map");
 #endif
 
     size_t inputLength = mapData.length();

--- a/irender.h
+++ b/irender.h
@@ -6,6 +6,7 @@
 
 #include <vector>
 #include <string>
+#include <stdint.h>
 
 #include "irender.h"
 #include "r_itexture.h"
@@ -23,12 +24,12 @@ enum DrawMode {
 };
 
 struct GLBatchDrawCmd { // TODO: Rename
-	int				offset;		// offset into vertex buffer (VBO)
-	int				indexOffset;	// offset into index buffer (iVBO)
-	uint32_t		numVerts;
-	uint32_t		numIndices;
-	bool			cullFace;
-	DrawMode		drawMode;
+	int		offset;		// offset into vertex buffer (VBO)
+	int		indexOffset;	// offset into index buffer (iVBO)
+	uint32_t	numVerts;
+	uint32_t	numIndices;
+	bool		cullFace;
+	DrawMode	drawMode;
 };
 
 class IRender {

--- a/polysoup.cpp
+++ b/polysoup.cpp
@@ -273,9 +273,8 @@ std::vector<MapPolygon> createPolysoup(Map map, SoupFlags soupFlags)
     std::vector<MapPolygon> polys;
     for (auto e = map.entities.begin(); e != map.entities.end(); e++) {
        
-        // Check if we wannt also want the brush entities included or not (default = not).
-        if ( !hasClassname(*e, "worldspawn") 
-            && (!hasClassname(*e, "func_group"))
+        // Check if we also want the brush entities included or not (default = not).
+        if ( !hasClassname(*e, "worldspawn") && !hasClassname(*e, "func_group")
             && (soupFlags == SOUP_GET_WORLDSPAWN_ONLY) ) {
             continue;
         }

--- a/r_gl_batch.cpp
+++ b/r_gl_batch.cpp
@@ -152,7 +152,7 @@ int GLBatch::Add(Tri* tris, uint32_t numTris, bool cullFace, DrawMode drawMode)
     return offset;
 }
 
-int GLBatch::Add(MapTri* tris, uint32_t numTris, bool cullFace, DrawMode drawMode) {
+int GLBatch::AddMapTris(MapTri* tris, uint32_t numTris, bool cullFace, DrawMode drawMode) {
     std::vector<Tri> rawTris{};
     rawTris.resize( numTris );
     for (int i = 0; i < numTris; i++) {

--- a/r_gl_batch.h
+++ b/r_gl_batch.h
@@ -20,7 +20,7 @@ public:
 	GLBatch(uint32_t maxVerts, uint32_t maxIndices);
 
 	int				Add(Tri* tris, uint32_t numTris, bool cullFace = true, DrawMode drawMode = DRAW_MODE_SOLID);
-	int				Add(MapTri* tris, uint32_t numTris, bool cullFace = true, DrawMode drawMode = DRAW_MODE_SOLID);
+	int				AddMapTris(MapTri* tris, uint32_t numTris, bool cullFace = true, DrawMode drawMode = DRAW_MODE_SOLID);
 	int				Add(Vertex* verts, uint32_t numVerts, bool cullFace = true, DrawMode drawMode = DRAW_MODE_LINES);
 	bool			Add(Vertex* verts, uint32_t numVerts, uint16_t* indices, uint32_t numIndices, int* out_offset, int* out_idxOffset, bool cullFace = true, DrawMode drawMode = DRAW_MODE_SOLID);
 	void			Bind();


### PR DESCRIPTION
Fixes messed up world geometry rendering when brushes are assigned to `func_group` entities in TrenchBroom.