### PR TITLE
Feat: door property usage

### DIFF
--- a/CWorld.cpp
+++ b/CWorld.cpp
@@ -15,11 +15,11 @@
 #include "dependencies/glm/ext.hpp"
 #include "dependencies/glm/gtx/quaternion.hpp"
 
+#include "utils/utils.h"
 #include "map_parser.h"
 #include "irender.h"
 #include "hkd_interface.h"
 #include "Entity/base_game_entity.h"
-#include "utils/utils.h"
 #include "Message/message_type.h"
 
 
@@ -286,7 +286,7 @@ std::vector<MapTri> CWorld::CreateMapTrisFromMapPolys(const std::vector<MapPolyg
 glm::vec3 CWorld::GetOrigin(const Entity* entity) {
     for ( const Property& property : entity->properties ) {
         if ( property.key == "origin" ) {
-            std::vector<float> values = ParseFloatValues(property.value);
+            std::vector<float> values = ParseFloatValues<float>(property.value);
             return glm::vec3(values[ 0 ], values[ 1 ], values[ 2 ]);
         }
     }
@@ -300,7 +300,7 @@ Waypoint CWorld::GetWaypoint(const Entity* entity) {
     Waypoint waypoint = {};
     for ( const Property& property : entity->properties ) {
         if ( property.key == "origin" ) {
-            std::vector<float> values = ParseFloatValues(property.value);
+            std::vector<float> values = ParseFloatValues<float>(property.value);
             waypoint.position = glm::vec3(values[ 0 ], values[ 1 ], values[ 2 ]);
         } else if ( property.key == "targetname" ) {
             waypoint.sTargetname = property.value;

--- a/Entity/Door/g_door.cpp
+++ b/Entity/Door/g_door.cpp
@@ -26,17 +26,8 @@ Door::Door(const std::vector<Property>& properties,
     m_pStateMachine->SetCurrentState(DoorClosed::Instance());
 
     // Get all the door's properties from the MAP file.
-    
-    for (int i = 0; i < properties.size(); i++) {
-        const Property& prop = properties[ i ];
-        if (prop.key == "angle") {
-            // TODO: Parse the value (prop.value is always a string)
-            // and assign to m_Angle;
-        }
-        else if (prop.key == "delay") {
-        }
-        // And so on...
-    }
+    BaseGameEntity::GetProperty<double>(properties, "speed", &m_Speed);
+    BaseGameEntity::GetProperty<double>(properties, "angle", &m_Angle);
 
     // Load the model from brushes
     m_Model = CreateModelFromBrushes( brushes );

--- a/Entity/Door/g_door.cpp
+++ b/Entity/Door/g_door.cpp
@@ -6,6 +6,11 @@
 
 #include <SDL.h>
 
+#define GLM_FORCE_RADIANS
+#include "../../dependencies/glm/glm.hpp"
+#include "../../dependencies/glm/ext.hpp"
+#include "../../dependencies/glm/gtx/quaternion.hpp"
+
 #include "g_door_states.h"
 #include "../../map_parser.h"
 #include "../../polysoup.h"
@@ -27,7 +32,14 @@ Door::Door(const std::vector<Property>& properties,
 
     // Get all the door's properties from the MAP file.
     BaseGameEntity::GetProperty<double>(properties, "speed", &m_Speed);
-    BaseGameEntity::GetProperty<double>(properties, "angle", &m_Angle);
+    float angle;
+    if ( BaseGameEntity::GetProperty<float>(properties, "angle", &angle) ) {
+        m_Angle = (int)angle;
+    }
+    float lip;
+    if ( BaseGameEntity::GetProperty<float>(properties, "lip", &lip) ) {
+        m_Lip = (int)lip;
+    }
 
     // Load the model from brushes
     m_Model = CreateModelFromBrushes( brushes );
@@ -42,6 +54,8 @@ Door::Door(const std::vector<Property>& properties,
     // NOTE: Just make doors golden for now. Obviously we texture them later.
     // TODO: This stuff happens quite common. Also: Maybe tris are sufficient?
     glm::vec4 triColor = glm::vec4(1.0f, 0.9f, 0.0f, 1.0f); 
+    glm::vec3 mins = glm::vec3(99999.0f);
+    glm::vec3 maxs = glm::vec3(-99999.0f);
     for (int i = 0; i < mapTris.size(); i++) {
 
         MapPolygon mapPoly = mapTris[ i ];
@@ -55,6 +69,17 @@ Door::Door(const std::vector<Property>& properties,
         Vertex C = { glm::vec3(mapPoly.vertices[2].pos.x, 
                                mapPoly.vertices[2].pos.y, 
                                mapPoly.vertices[2].pos.z) };
+
+        float minX = glm::min( A.pos.x, B.pos.x, C.pos.x );
+        float minY = glm::min( A.pos.y, B.pos.y, C.pos.y );
+        float minZ = glm::min( A.pos.z, B.pos.z, C.pos.z );
+        float maxX = glm::max( A.pos.x, B.pos.x, C.pos.x );
+        float maxY = glm::max( A.pos.y, B.pos.y, C.pos.y );
+        float maxZ = glm::max( A.pos.z, B.pos.z, C.pos.z );
+
+        mins = glm::min( mins, glm::vec3(minX, minY, minZ) );
+        maxs = glm::max( maxs, glm::vec3(maxX, maxY, maxZ) );
+
         A.color = triColor;
         B.color = triColor;
         C.color = triColor;
@@ -62,6 +87,30 @@ Door::Door(const std::vector<Property>& properties,
 
         m_MapTris.push_back(tri);
     }
+
+    m_Mins = mins;
+    m_Maxs = maxs;
+
+    // Distance to travel is the width of the door in the travel direction.
+    glm::vec3 worldUp = glm::vec3(0.0f, 0.0f, 1.0f);
+    glm::vec3 worldForward = glm::vec3(0.0f, 1.0f, 0.0f);
+    glm::quat qDir;
+    if (m_Angle == -1 ) { // Door moves upward
+        qDir = glm::angleAxis( glm::radians(-90.0f), worldForward ); 
+    }
+    else if (m_Angle == -2) { // Door moves downward
+        qDir = glm::angleAxis( glm::radians(90.0f), worldForward ); 
+    }
+    else {
+        qDir = glm::angleAxis( glm::radians((float)m_Angle), worldUp );
+    }
+
+    m_Direction = glm::rotate( qDir, m_Direction );
+
+    // Compute distance to travel
+    glm::vec3 minsToMaxs = maxs - mins;
+    glm::vec3 directedLength = m_Direction * minsToMaxs;
+    m_Distance = glm::length(directedLength) - (double)m_Lip;
 }
 
 bool Door::HandleMessage(const Telegram& telegram) {

--- a/Entity/Door/g_door.h
+++ b/Entity/Door/g_door.h
@@ -67,12 +67,20 @@ public:
 
     // This is the angle in degrees the door slides to when opening.
     // On closing it is just the opposite direction.
-    double m_Angle = 0.0;
+    int m_Angle = 0;
+
+    int m_Lip = 0;
 
     // The distance the door travels when opening.
     double m_Distance = 70.0;
 
     double m_CurrentDistance = 0.0;
+
+    // +x is angle = 0
+    glm::vec3 m_Direction = glm::vec3(1.0f, 0.0f, 0.0f);
+
+    glm::vec3 m_Mins = glm::vec3(0.0f);
+    glm::vec3 m_Maxs = glm::vec3(0.0f);
 };
 
 #endif // _DOOR_H_

--- a/Entity/Door/g_door.h
+++ b/Entity/Door/g_door.h
@@ -63,7 +63,7 @@ public:
     double m_ClosingDelayInMs = 100.0;
 
     // Speed the door opens/closes with
-    double m_Speed = 30.0;
+    double m_Speed = 100.0;
 
     // This is the angle in degrees the door slides to when opening.
     // On closing it is just the opposite direction.

--- a/Entity/Door/g_door_states.cpp
+++ b/Entity/Door/g_door_states.cpp
@@ -68,28 +68,31 @@ void DoorOpening::Execute(Door* pDoor) {
     // to variations of the deltaTime and floating
     // point rounding errors.
 
-    // Check if door has reached its opened state.
-    // If so switch to the opened state.
-    //printf("dt: %f\n", GetDeltaTime());
-    pDoor->m_CurrentDistance += pDoor->m_Speed * GetDeltaTime() / 1000.0;
-    /*printf("current distance: %f\n", pDoor->m_CurrentDistance);*/
-    if ( pDoor->m_CurrentDistance >= pDoor->m_Distance ) {
-        pDoor->GetFSM()->ChangeState(DoorOpened::Instance());
-
-        return;
-    }
+    double distance = glm::clamp(pDoor->m_Speed * GetDeltaTime() / 1000.0,
+                                0.0, pDoor->m_Distance);
 
     // Open the door.
     
+    // Move the render representation.
     HKD_Model* doorModel = pDoor->GetModel();
-    doorModel->position.z += pDoor->m_Speed *GetDeltaTime() / 1000.0;
+    glm::vec3 travel =  (float)distance * pDoor->m_Direction;
+    doorModel->position += travel;
+  
+    // Move the CPU side representation for collision.
     std::vector<MapTri>& mapTris = pDoor->MapTris();
     for ( int i = 0; i < mapTris.size(); i++ ) {
         MapTri& mapTri = mapTris[ i ];
         for ( int j = 0; j < 3; j++ ) {
             Vertex& v = mapTri.tri.vertices[ j ];
-            v.pos.z += pDoor->m_Speed * GetDeltaTime() / 1000.0;
+            v.pos += travel;
         }
+    }
+    
+    // Check if door has reached its opened state.
+    // If so switch to the opened state.
+    pDoor->m_CurrentDistance += distance;
+    if ( pDoor->m_CurrentDistance >= pDoor->m_Distance ) {
+        pDoor->GetFSM()->ChangeState(DoorOpened::Instance());
     }
 }
 

--- a/Entity/Enemy/g_enemy.cpp
+++ b/Entity/Enemy/g_enemy.cpp
@@ -27,8 +27,9 @@ Enemy::Enemy(const std::vector<Property>& properties)
     m_pStateMachine->SetCurrentState(EnemyIdle::Instance());
    
     // We want position and, if applicable, a target.
-    m_Position = BaseGameEntity::GetProperty<glm::vec3>(properties, "origin");
-    m_Target = BaseGameEntity::GetProperty<std::string>(properties, "target");
+    BaseGameEntity::GetProperty<glm::vec3>(properties, "origin", &m_Position);
+    // FIX: Mem Leak on exit if target is not being set.
+    BaseGameEntity::GetProperty<std::string>(properties, "target", &m_Target);
 
     LoadModel("models/multiple_anims/multiple_anims.iqm", m_Position);
     m_Velocity = glm::vec3(0.0f, 0.0f, 0.0f);

--- a/Entity/Player/g_player.cpp
+++ b/Entity/Player/g_player.cpp
@@ -108,7 +108,7 @@ void Player::UpdatePlayerModel() {
     
     double dt = GetDeltaTime();
     float followCamSpeed = 0.03f;
-    float followTurnSpeed = 0.1f;
+    float followTurnSpeed = 0.3f;
     if ( KeyPressed(SDLK_LSHIFT) ) {
         followCamSpeed *= 0.3f;
         followTurnSpeed *= 0.3f;

--- a/Entity/base_game_entity.h
+++ b/Entity/base_game_entity.h
@@ -38,30 +38,43 @@ class BaseGameEntity {
     }
 
     template<typename T>
-    T GetProperty(const std::vector<Property>& properties, std::string propName) {
+    bool GetProperty(const std::vector<Property>& properties, std::string propName, T* value) {
         for ( const Property& property : properties ) {
             if ( property.key == propName ) {
-                return ParseProperty<T>(property.value);
+                *value = ParseProperty<T>(property.value);
+                return true;
             }
         }
 
-        return T{};
+        return false;
     }
 
     template<typename T>
-    T ParseProperty(const std::string& value);
+    T ParseProperty(const std::string& sValue);
 
     template<>
     glm::vec3 ParseProperty<glm::vec3>(const std::string& sValue) {
-        std::vector<float> origin = ParseFloatValues(sValue);
+        std::vector<float> origin = ParseFloatValues<float>(sValue);
         return glm::vec3( origin[0], origin[1], origin[2] );
     }
 
     template<>
-    std::string ParseProperty<std::string>(const std::string& value) {
-        return value;
+    std::string ParseProperty<std::string>(const std::string& sValue) {
+        return sValue;
     }
 
+    template<>
+    float ParseProperty<float>(const std::string& sValue) {
+        std::vector<float> floats = ParseFloatValues<float>(sValue);
+        return floats[ 0 ];
+    }
+    
+    template<>
+    double ParseProperty<double>(const std::string& sValue) {
+        std::vector<double> floats = ParseFloatValues<double>(sValue);
+        return floats[ 0 ];
+    }
+    
     virtual ~BaseGameEntity() = default;
 
     // all entities must implement an update function

--- a/game.cpp
+++ b/game.cpp
@@ -57,7 +57,7 @@ void Game::Init() {
 #ifdef _WIN32
     std::string mapData = loadTextFile(m_ExePath + "../../assets/maps/enemy_test.map");
 #elif __LINUX__
-    std::string mapData = loadTextFile(m_ExePath + "../assets/maps/Prototype.map");
+    std::string mapData = loadTextFile(m_ExePath + "../assets/maps/temple2.map");
 #endif
 
     size_t inputLength = mapData.length();

--- a/utils/utils.cpp
+++ b/utils/utils.cpp
@@ -71,27 +71,13 @@ std::vector<std::string> SplitString(const std::string& input, char delimiter) {
     return tokens;
 }
 
-std::vector<float> ParseFloatValues(const std::string& input) {
-    std::vector<float> values;
-    const char* str = input.c_str();
-    float value = 0.0;
-    bool parsingNumber = false;
 
-    while ( *str != '\0' ) {
-        if ( std::isdigit(*str) || *str == '-' || *str == '.' ) {
-            parsingNumber = true;
-            char* end;
-            value = std::strtof(str, &end);
-            values.push_back(value);
-            str = end;
-        } else if ( parsingNumber && *str == ' ' ) {
-            parsingNumber = false;
-            str++;
-        } else {
-            str++;
-        }
-    }
-
-    return values;
+template <>
+float StringToFloat<float>(const char* str, char** end) {
+    return std::strtof(str, end);
 }
-
+    
+template <>
+double StringToFloat<double>(const char* str, char** end) {
+    return std::strtod(str, end);
+}

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -1,5 +1,6 @@
 #ifndef _UTILS_H_
 #define _UTILS_H_
+
 #include <glm/glm.hpp>
 #include <string>
 #include <vector>
@@ -8,7 +9,41 @@ double                      GetDeltaTime();
 float                       RandBetween(float min, float max);
 bool                        IsStringFloat(const std::string& string);
 std::vector<std::string>    SplitString(const std::string& input, char delimiter);
-std::vector<float>          ParseFloatValues(const std::string& input);
+
+template<typename T>
+T StringToFloat(const char* str, char** end);
+
+template<>
+float StringToFloat<float>(const char* str, char** end);
+
+template<>
+double StringToFloat<double>(const char* str, char** end);
+
+template<typename T>
+std::vector<T> ParseFloatValues(const std::string& input) {
+    std::vector<T> values;
+    const char* str = input.c_str();
+    T value = 0.0;
+    bool parsingNumber = false;
+
+    while ( *str != '\0' ) {
+        if ( std::isdigit(*str) || *str == '-' || *str == '.' ) {
+            parsingNumber = true;
+            char* end;
+            value = StringToFloat<T>(str, &end);
+            values.push_back(value);
+            str = end;
+        } else if ( parsingNumber && *str == ' ' ) {
+            parsingNumber = false;
+            str++;
+        } else {
+            str++;
+        }
+    }
+
+    return values;
+}
+
 
 #endif
 


### PR DESCRIPTION
Doors work like in Quake:
- angle = -1 : Door moves up
- angle = -2 : Door moves down
- 0 <= angle < 360 : Door moves parallel to the xy plane.
- speed: How fast the door moves

The door moves as far as its axis alignd bounding box dimensions into the movement direction.
- lip: If > 0 the door doesn't move as far. Example: If the movement direction is (1, 0, 0) and the door is
200 units wide in x-direction, a lip of 50 won't move the door by 200 units but only 150.

See: https://quakewiki.org/wiki/func_door

What does not work: When a door moves toward the player and the player stays still the door moves through
the player. This is because the collision checks for a non 0 velocity vector of the player. 