### PR TITLE
feat: apply clang-format to our own sourcefiles

### DIFF
--- a/Body.cpp
+++ b/Body.cpp
@@ -6,8 +6,8 @@
 
 glm::vec3 Body::GetCenterOfMassWorldSpace() const {
     glm::vec3 centerOfMass = m_Shape->GetCenterOfMass();
-    glm::mat3 r = glm::mat3_cast(m_Orientation);
-    centerOfMass = r * centerOfMass;
+    glm::mat3 r            = glm::mat3_cast(m_Orientation);
+    centerOfMass           = r * centerOfMass;
     return m_Position + centerOfMass;
 }
 
@@ -15,26 +15,26 @@ glm::vec3 Body::GetCenterOfMassModelSpace() const {
     return m_Shape->GetCenterOfMass();
 }
 
-glm::vec3 Body::WorldSpaceToBodySpace(glm::vec3 &pt) {
+glm::vec3 Body::WorldSpaceToBodySpace(glm::vec3& pt) {
     glm::vec3 tmp = pt - GetCenterOfMassWorldSpace();
 
     // m_Orientation is the rotation in WorldSpace.
     // So we need to rotate back to get the original pt in BodySpace
     glm::quat inverseOrient = inverse(m_Orientation);
 
-    glm::mat3 r = glm::mat3_cast(inverseOrient);
+    glm::mat3 r         = glm::mat3_cast(inverseOrient);
     glm::vec3 bodySpace = r * tmp;
     return bodySpace;
 }
 
-glm::vec3 Body::BodySpaceToWorldSpace(glm::vec3 &pt) {
-    glm::mat3 r = glm::mat3_cast(m_Orientation);
+glm::vec3 Body::BodySpaceToWorldSpace(glm::vec3& pt) {
+    glm::mat3 r       = glm::mat3_cast(m_Orientation);
     glm::vec3 ptWorld = r * pt;
     return GetCenterOfMassWorldSpace() + ptWorld;
 }
 
-void Body::ApplyImpulseLinear(glm::vec3 &impulse) {
-    if (m_InvMass <= 0.0f) return;
+void Body::ApplyImpulseLinear(glm::vec3& impulse) {
+    if ( m_InvMass <= 0.0f ) return;
 
     m_LinearVelocity += impulse * m_InvMass;
 }

--- a/Body.h
+++ b/Body.h
@@ -5,13 +5,13 @@
 #ifndef BODY_H
 #define BODY_H
 
-#include <glm/glm.hpp>
 #include <glm/ext.hpp>
+#include <glm/glm.hpp>
 
 #include "Shape.h"
 
 class Body {
-public:
+  public:
     glm::vec3 GetCenterOfMassWorldSpace() const;
     glm::vec3 GetCenterOfMassModelSpace() const;
 
@@ -20,14 +20,12 @@ public:
 
     void ApplyImpulseLinear(glm::vec3& impulse);
 
-    glm::vec3   m_Position;
-    glm::quat   m_Orientation;
-    glm::vec3   m_LinearVelocity;
-    float       m_InvMass;
-    float       m_Elasticity;
-    Shape*      m_Shape;
+    glm::vec3 m_Position;
+    glm::quat m_Orientation;
+    glm::vec3 m_LinearVelocity;
+    float     m_InvMass;
+    float     m_Elasticity;
+    Shape*    m_Shape;
 };
-
-
 
 #endif //BODY_H

--- a/CWorld.cpp
+++ b/CWorld.cpp
@@ -7,21 +7,20 @@
 #include <assert.h>
 
 #include <string.h>
-#include <vector>
 #include <unordered_set>
+#include <vector>
 
 #define GLM_FORCE_RADIANS
-#include "dependencies/glm/glm.hpp"
 #include "dependencies/glm/ext.hpp"
+#include "dependencies/glm/glm.hpp"
 #include "dependencies/glm/gtx/quaternion.hpp"
 
-#include "utils/utils.h"
-#include "map_parser.h"
-#include "irender.h"
-#include "hkd_interface.h"
 #include "Entity/base_game_entity.h"
 #include "Message/message_type.h"
-
+#include "hkd_interface.h"
+#include "irender.h"
+#include "map_parser.h"
+#include "utils/utils.h"
 
 CWorld* CWorld::Instance() {
     static CWorld m_World;
@@ -32,8 +31,8 @@ CWorld* CWorld::Instance() {
 void CWorld::InitWorldFromMap(const Map& map) {
     // Get some subsystems
     EntityManager* m_pEntityManager = EntityManager::Instance();
-    IRender* renderer = GetRenderer();
-   
+    IRender*       renderer         = GetRenderer();
+
     // TODO: Init via .MAP property.
     m_Gravity = glm::vec3(0.0f, 0.0f, -0.5f);
 
@@ -41,7 +40,7 @@ void CWorld::InitWorldFromMap(const Map& map) {
     std::vector<MapPolygon> polysoup = createPolysoup(map);
     // Convert to tris
     m_MapTris = CWorld::CreateMapTrisFromMapPolys(polysoup);
-    
+
     m_StaticGeometryCount = m_MapTris.size();
 
     // Now initialize all the entities. Those also include brush
@@ -58,16 +57,16 @@ void CWorld::InitWorldFromMap(const Map& map) {
             const Property& prop = e.properties[ j ];
             if ( prop.key == "classname" ) {
                 if ( prop.value == "func_door" ) {
-                    Door* door = new Door(e.properties, e.brushes); 
-                    m_pEntityManager->RegisterEntity(door); 
+                    Door* door = new Door(e.properties, e.brushes);
+                    m_pEntityManager->RegisterEntity(door);
                     HKD_Model* model = door->GetModel();
-                    m_BrushModels.push_back( model );
+                    m_BrushModels.push_back(model);
                     std::vector<MapTri>& mapTris = door->MapTris();
-                    m_pBrushMapTris.push_back( &mapTris );
+                    m_pBrushMapTris.push_back(&mapTris);
                 } else if ( prop.value == "info_player_start" ) {
-                    assert( m_pPlayerEntity == nullptr ); // There can only be one
+                    assert(m_pPlayerEntity == nullptr); // There can only be one
                     glm::vec3 playerStartPosition = CWorld::GetOrigin(&e);
-                    m_pPlayerEntity = new Player(playerStartPosition);
+                    m_pPlayerEntity               = new Player(playerStartPosition);
                     m_pEntityManager->RegisterEntity(m_pPlayerEntity);
                     // Upload this model to the GPU. Not using the handle atm.
                     int hPlayerModel = renderer->RegisterModel(m_pPlayerEntity->GetModel());
@@ -75,7 +74,7 @@ void CWorld::InitWorldFromMap(const Map& map) {
                 } else if ( prop.value == "monster_soldier" ) {
                     // just a placeholder entity from trenchbroom/quake
                     glm::vec3 enemyStartPosition = CWorld::GetOrigin(&e);
-                    Enemy* enemy = new Enemy(e.properties);
+                    Enemy*    enemy              = new Enemy(e.properties);
                     m_pEntityManager->RegisterEntity(enemy);
 
                     int hEnemyModel = renderer->RegisterModel(enemy->GetModel());
@@ -92,24 +91,24 @@ void CWorld::InitWorldFromMap(const Map& map) {
 
     // NOTE: At the moment, maps without an 'info_player_start' are not allowed.
     // FIX: (Michael): I think it should be possible to not have a player?
-    assert( m_pPlayerEntity != nullptr );
+    assert(m_pPlayerEntity != nullptr);
 
     // Create paths from waypoints
     std::unordered_set<std::string> visited; // waypoints that are already part of any path
 
-    for (const auto& [targetname, waypoint] : m_NameToWaypoint) {
+    for ( const auto& [ targetname, waypoint ] : m_NameToWaypoint ) {
         // Skip waypoints already in a patrol path
-        if (visited.count(targetname)) {
+        if ( visited.count(targetname) ) {
             continue;
         }
 
         // Start a new patrol path
-        PatrolPath currentPath;
-        Waypoint current = waypoint;
+        PatrolPath                      currentPath;
+        Waypoint                        current = waypoint;
         std::unordered_set<std::string> pathVisited; // Track for cycles
 
         while ( !current.target.empty() ) { // Does the waypoint point to another?
-            if (pathVisited.count(current.targetname)) {
+            if ( pathVisited.count(current.targetname) ) {
                 // Cycle detected, break the path
                 break;
             }
@@ -120,7 +119,7 @@ void CWorld::InitWorldFromMap(const Map& map) {
 
             // Move to the next waypoint if it exists
             auto it = m_NameToWaypoint.find(current.target);
-            if (it != m_NameToWaypoint.end()) {
+            if ( it != m_NameToWaypoint.end() ) {
                 current = it->second;
             } else {
                 break; // End of the chain
@@ -140,18 +139,18 @@ void CWorld::InitWorldFromMap(const Map& map) {
     // FIX: Need a target to Entity map. But waypoints are no entities at the moment.
     // So atm it is expected that the target the entity points to is a waypoint!
     std::vector<BaseGameEntity*> entities = EntityManager::Instance()->Entities();
-    for (int i = 0; i < entities.size(); i++) {
-        BaseGameEntity* entity = entities[i];
-        if (entity->Type() == ET_ENEMY) {
+    for ( int i = 0; i < entities.size(); i++ ) {
+        BaseGameEntity* entity = entities[ i ];
+        if ( entity->Type() == ET_ENEMY ) {
             Enemy* enemy = (Enemy*)entity;
             if ( !enemy->m_Target.empty() ) {
                 // Find the waypoint and its path
                 // FIX: This also is easier if waypoints are entities
-                for (int j = 0; j < m_Paths.size(); j++) {
-                    PatrolPath& path = m_Paths[j];
+                for ( int j = 0; j < m_Paths.size(); j++ ) {
+                    PatrolPath&           path   = m_Paths[ j ];
                     std::vector<Waypoint> points = path.GetPoints();
-                    for (int k = 0; k < points.size(); k++) {
-                        Waypoint point = points[k];
+                    for ( int k = 0; k < points.size(); k++ ) {
+                        Waypoint point = points[ k ];
                         if ( enemy->m_Target == point.targetname ) {
                             // copy its path for internal use in this enemy
                             PatrolPath* pPathCopy = new PatrolPath(&path);
@@ -168,9 +167,9 @@ void CWorld::InitWorldFromMap(const Map& map) {
 
 void CWorld::CollideEntitiesWithWorld() {
     std::vector<BaseGameEntity*> entities = EntityManager::Instance()->Entities();
-    double dt = GetDeltaTime();
-    for (int i = 0; i < entities.size(); i++) {
-        BaseGameEntity* pEntity = entities[i];
+    double                       dt       = GetDeltaTime();
+    for ( int i = 0; i < entities.size(); i++ ) {
+        BaseGameEntity* pEntity = entities[ i ];
 
         // FIX: Higher level entity type or entity flags (eg. FLAG_COLLIDABLE).
         if ( (pEntity->Type() == ET_PLAYER) || (pEntity->Type() == ET_ENEMY) ) {
@@ -184,7 +183,6 @@ void CWorld::CollideEntitiesWithWorld() {
                                                                       StaticGeometryCount(),
                                                                       m_pBrushMapTris);
 
-
             // Iterate over brush entities and check for collision as well...
 
             pEntity->UpdatePosition(collisionInfo.basePos);
@@ -196,40 +194,37 @@ void CWorld::CollideEntitiesWithWorld() {
 // We need to recheck all the entities in the inner loop because only
 // the first entity from the outer loop is the one who 'pushes'.
 void CWorld::CollideEntities() {
-    
+
     std::vector<BaseGameEntity*> entities = EntityManager::Instance()->Entities();
-    double dt = GetDeltaTime();
-  
+    double                       dt       = GetDeltaTime();
+
     // Push Touch: Entity 'bumps' into other entity.
-    for (int i = 0; i < entities.size(); i++) {
-        BaseGameEntity* pEntity = entities[i];
-        
+    for ( int i = 0; i < entities.size(); i++ ) {
+        BaseGameEntity* pEntity = entities[ i ];
+
         // Ignore non moving entities. They cannot 'bump' without velocity.
         if ( glm::length(pEntity->m_Velocity) <= 0.0f ) {
             continue;
         }
 
-        for (int j = 0; j < entities.size(); j++) {
-  
-            BaseGameEntity* pOther = entities[j];
+        for ( int j = 0; j < entities.size(); j++ ) {
+
+            BaseGameEntity* pOther = entities[ j ];
             if ( pOther->ID() == pEntity->ID() ) { // Don't collide with itself.
                 continue;
             }
-   
+
             if ( pOther->Type() == ET_DOOR ) {
-                Door* pDoor = (Door*)pOther;
-                EllipsoidCollider ec = pEntity->GetEllipsoidCollider();
-                CollisionInfo ci = PushTouch(ec,
-                                             static_cast<float>(dt) * pEntity->m_Velocity, 
-                                             pDoor->MapTris().data(), 
-                                             pDoor->MapTris().size());
-                if (ci.didCollide) { 
+                Door*             pDoor = (Door*)pOther;
+                EllipsoidCollider ec    = pEntity->GetEllipsoidCollider();
+                CollisionInfo     ci    = PushTouch(
+                    ec, static_cast<float>(dt) * pEntity->m_Velocity, pDoor->MapTris().data(), pDoor->MapTris().size());
+                if ( ci.didCollide ) {
                     printf("COLLIDED!\n");
                     Dispatcher->DispatchMessage(
                         SEND_MSG_IMMEDIATELY, pEntity->ID(), pDoor->ID(), message_type::Collision, 0);
                 }
             }
-            
         }
     }
 }
@@ -238,9 +233,9 @@ std::vector<MapTri> CWorld::CreateMapTrisFromMapPolys(const std::vector<MapPolyg
     // Get the renderer to register the textures
     IRender* renderer = GetRenderer();
 
-    std::vector<MapTri> mapTris{};
-    std::vector<MapPolygon> tris = triangulate(mapPolys);
-    glm::vec4 triColor = glm::vec4(0.1f, 0.8f, 1.0f, 1.0f);
+    std::vector<MapTri>     mapTris{};
+    std::vector<MapPolygon> tris     = triangulate(mapPolys);
+    glm::vec4               triColor = glm::vec4(0.1f, 0.8f, 1.0f, 1.0f);
     for ( int i = 0; i < tris.size(); i++ ) {
         MapPolygon mapPoly = tris[ i ];
 
@@ -251,10 +246,10 @@ std::vector<MapTri> CWorld::CreateMapTrisFromMapPolys(const std::vector<MapPolyg
         Vertex C = { glm::vec3(mapPoly.vertices[ 2 ].pos.x, mapPoly.vertices[ 2 ].pos.y, mapPoly.vertices[ 2 ].pos.z),
                      mapPoly.vertices[ 2 ].uv };
 
-        A.color = triColor;
-        B.color = triColor;
-        C.color = triColor;
-        MapTri tri = { .tri = { A, B, C } };
+        A.color         = triColor;
+        B.color         = triColor;
+        C.color         = triColor;
+        MapTri tri      = { .tri = { A, B, C } };
         tri.textureName = mapPoly.textureName;
         //FIX: Search through all supported image formats not just PNG.
         tri.hTexture = renderer->RegisterTextureGetHandle(tri.textureName + ".tga");
@@ -284,7 +279,7 @@ Waypoint CWorld::GetWaypoint(const Entity* entity) {
     for ( const Property& property : entity->properties ) {
         if ( property.key == "origin" ) {
             std::vector<float> values = ParseValues<float>(property.value);
-            waypoint.position = glm::vec3(values[ 0 ], values[ 1 ], values[ 2 ]);
+            waypoint.position         = glm::vec3(values[ 0 ], values[ 1 ], values[ 2 ]);
         } else if ( property.key == "targetname" ) {
             waypoint.targetname = property.value;
 
@@ -295,5 +290,3 @@ Waypoint CWorld::GetWaypoint(const Entity* entity) {
 
     return waypoint;
 }
-
-

--- a/CWorld.h
+++ b/CWorld.h
@@ -6,34 +6,34 @@
 #define _CWORLD_H_
 
 #define GLM_FORCE_RADIANS
-#include "dependencies/glm/glm.hpp"
 #include "dependencies/glm/ext.hpp"
+#include "dependencies/glm/glm.hpp"
 #include "dependencies/glm/gtx/quaternion.hpp"
 
-#include <vector>
 #include <stdint.h>
 #include <unordered_map>
+#include <vector>
 
-#include "r_common.h"
 #include "./Entity/base_game_entity.h"
 #include "Entity/Door/g_door.h"
 #include "Entity/Enemy/g_enemy.h"
-#include "Entity/Player/g_player.h"
-#include "Entity/FollowCamera/g_follow_camera.h"
 #include "Entity/FlyCamera/g_fly_camera.h"
+#include "Entity/FollowCamera/g_follow_camera.h"
+#include "Entity/Player/g_player.h"
 #include "Entity/entity_manager.h"
 #include "Path/path.h"
 #include "map_parser.h"
 #include "polysoup.h"
+#include "r_common.h"
 #include "r_model.h"
 
 class CWorld {
-public:
+  public:
     static CWorld* Instance();
-    void        InitWorldFromMap(const Map& map);
-    void        CollideEntitiesWithWorld();
-    void        CollideEntities();
-    
+    void           InitWorldFromMap(const Map& map);
+    void           CollideEntitiesWithWorld();
+    void           CollideEntities();
+
     /*
     * Easier to understand in code when only the number of
     * static tris is needed.
@@ -58,30 +58,27 @@ public:
         return m_BrushModels;
     }
 
-    static glm::vec3            GetOrigin(const Entity* entity);
-    static Waypoint             GetWaypoint(const Entity* entity);
-    static std::vector<MapTri>  CreateMapTrisFromMapPolys(const std::vector<MapPolygon>& mapPolys);
-    
-    std::vector<MapTri>          m_MapTris;
-    glm::vec3                    m_Gravity;
+    static glm::vec3           GetOrigin(const Entity* entity);
+    static Waypoint            GetWaypoint(const Entity* entity);
+    static std::vector<MapTri> CreateMapTrisFromMapPolys(const std::vector<MapPolygon>& mapPolys);
+
+    std::vector<MapTri> m_MapTris;
+    glm::vec3           m_Gravity;
     // FIX: Where to put paths? Shouldn't they also be entities themselves??
     std::unordered_map<std::string, Waypoint> m_NameToWaypoint;
-    std::vector<PatrolPath>      m_Paths;
+    std::vector<PatrolPath>                   m_Paths;
 
-private:
-    CWorld() = default;
+  private:
+    CWorld()  = default;
     ~CWorld() = default;
 
-    uint64_t                             m_StaticGeometryCount;
+    uint64_t m_StaticGeometryCount;
     // FIX: Does the player really *always* have to exist?
-    Player*                              m_pPlayerEntity = nullptr;
-    std::vector<HKD_Model*>              m_Models; 
-    std::vector<HKD_Model*>              m_BrushModels;
+    Player*                 m_pPlayerEntity = nullptr;
+    std::vector<HKD_Model*> m_Models;
+    std::vector<HKD_Model*> m_BrushModels;
     // Keep references to brush entities' map tris
-    std::vector< std::vector<MapTri>* >  m_pBrushMapTris;
+    std::vector<std::vector<MapTri>*> m_pBrushMapTris;
 };
 
-
-
 #endif // _CWORLD_H_
-

--- a/CircularBuffer.cpp
+++ b/CircularBuffer.cpp
@@ -5,23 +5,25 @@
 CircularBuffer::CircularBuffer(uint32_t maxSize) {
     m_buffer.resize(maxSize);
     m_maxSize = maxSize;
-    m_pos = 0;
-    m_isFull = false;
+    m_pos     = 0;
+    m_isFull  = false;
 }
 
 void CircularBuffer::Push(std::string str) {
-    m_buffer[m_pos] = str;
-    if (++m_pos == m_maxSize) { // more efficient wraparound than with modulo: https://embeddedartistry.com/blog/2017/05/17/creating-a-circular-buffer-in-c-and-c/#comment-21639
-        m_pos = 0;
+    m_buffer[ m_pos ] = str;
+    if (
+        ++m_pos
+        == m_maxSize ) { // more efficient wraparound than with modulo: https://embeddedartistry.com/blog/2017/05/17/creating-a-circular-buffer-in-c-and-c/#comment-21639
+        m_pos    = 0;
         m_isFull = true;
     }
 }
 
 bool CircularBuffer::Get(uint32_t offset, std::string* str) {
-    if (offset >= Size() || Empty()) return false;
+    if ( offset >= Size() || Empty() ) return false;
     int pos = m_pos - 1 - offset;
-    if (pos < 0) pos += m_maxSize;
-    *str = m_buffer[pos];
+    if ( pos < 0 ) pos += m_maxSize;
+    *str = m_buffer[ pos ];
     return true;
 }
 
@@ -36,4 +38,3 @@ int CircularBuffer::Size() {
 int CircularBuffer::MaxSize() {
     return m_maxSize;
 }
-

--- a/CircularBuffer.h
+++ b/CircularBuffer.h
@@ -7,16 +7,15 @@
 
 #include <stdint.h>
 
-
 /** Circular string buffer. */
 class CircularBuffer {
-private:
+  private:
     std::vector<std::string> m_buffer;
-    int m_maxSize;
-    int m_pos;
-    bool m_isFull;
+    int                      m_maxSize;
+    int                      m_pos;
+    bool                     m_isFull;
 
-public:
+  public:
     CircularBuffer(uint32_t maxSize);
 
     /** Add the given string to the buffer. */
@@ -27,9 +26,8 @@ public:
      */
     bool Get(uint32_t offset, std::string* str);
     bool Empty();
-    int Size();
-    int MaxSize();
+    int  Size();
+    int  MaxSize();
 };
 
 #endif // CIRCULARBUFFER_H
-

--- a/Clock/clock.cpp
+++ b/Clock/clock.cpp
@@ -6,14 +6,12 @@
 #include "clock.h"
 #include "SDL_timer.h"
 
-CrudeTimer* CrudeTimer::Instance()
-{
-	static CrudeTimer instance;
+CrudeTimer* CrudeTimer::Instance() {
+    static CrudeTimer instance;
 
-	return &instance;
+    return &instance;
 }
 
 double CrudeTimer::GetTime() {
-	return SDL_GetTicks();
+    return SDL_GetTicks();
 }
-

--- a/Clock/clock.h
+++ b/Clock/clock.h
@@ -9,14 +9,14 @@
 
 class CrudeTimer {
   private:
-	CrudeTimer() = default;
+    CrudeTimer() = default;
 
   public:
-	// copy ctor and assignment should be deleted
-	CrudeTimer(const CrudeTimer &) = delete;
-	CrudeTimer &operator=(const CrudeTimer &) = delete;
-	static CrudeTimer *Instance();
-	[[nodiscard]] double GetTime();
+    // copy ctor and assignment should be deleted
+    CrudeTimer(const CrudeTimer&)                     = delete;
+    CrudeTimer&          operator=(const CrudeTimer&) = delete;
+    static CrudeTimer*   Instance();
+    [[nodiscard]] double GetTime();
 };
 
 #endif // CLOCK_H

--- a/Console/CommandManager.cpp
+++ b/Console/CommandManager.cpp
@@ -2,16 +2,16 @@
 
 #include <sstream>
 
-#include "VariableManager.h"
 #include "Console.h"
+#include "VariableManager.h"
 
 std::map<std::string, ConsoleCommand*> CommandManager::commands;
 
 std::vector<std::string> CommandManager::TokenizeString(const std::string& input) {
     std::vector<std::string> tokens;
-    std::istringstream stream(input);
-    std::string token;
-    while (stream >> token) { // split at spaces
+    std::istringstream       stream(input);
+    std::string              token;
+    while ( stream >> token ) { // split at spaces
         tokens.push_back(token);
     }
     return tokens;
@@ -19,14 +19,14 @@ std::vector<std::string> CommandManager::TokenizeString(const std::string& input
 
 ConsoleCommand* CommandManager::Add(std::string name, CommandHandler function) {
     ConsoleCommand* cmd = Find(name);
-    if (cmd) {
+    if ( cmd ) {
         return cmd;
-    } else if (VariableManager::Find(name)) {
+    } else if ( VariableManager::Find(name) ) {
         Console::Printf("Can't add command, %s is a variable.", cmd->name);
         return nullptr;
     }
     cmd = new ConsoleCommand(name, function);
-    commands.insert({name, cmd});
+    commands.insert({ name, cmd });
     return cmd;
 }
 
@@ -41,12 +41,12 @@ bool CommandManager::Exists(std::string name) {
 
 void CommandManager::ExecuteString(std::string input) {
     std::vector<std::string> args = TokenizeString(input);
-    if (args.size() > 0) {
-        ConsoleCommand* cmd = Find(args[0]);
-        if (cmd) {
+    if ( args.size() > 0 ) {
+        ConsoleCommand* cmd = Find(args[ 0 ]);
+        if ( cmd ) {
             cmd->function(args);
-        } else if (!VariableManager::HandleCommand(args)) {
-            Console::Printf("Command '%s' not found.", args[0]);
+        } else if ( !VariableManager::HandleCommand(args) ) {
+            Console::Printf("Command '%s' not found.", args[ 0 ]);
         }
     }
 }

--- a/Console/CommandManager.h
+++ b/Console/CommandManager.h
@@ -5,13 +5,15 @@
 #include <string>
 #include <vector>
 
-typedef void (*CommandHandler) (std::vector<std::string> args);
+typedef void (*CommandHandler)(std::vector<std::string> args);
 
 struct ConsoleCommand {
     const std::string name;
-    CommandHandler function;
+    CommandHandler    function;
     // TODO: consider adding description / help text and help command
-    ConsoleCommand(std::string n, CommandHandler f) : name(n), function(f) {}
+    ConsoleCommand(std::string n, CommandHandler f)
+        : name(n),
+          function(f) {}
 };
 
 /**
@@ -19,15 +21,15 @@ struct ConsoleCommand {
  * Loosely based on Quake's (QSS-M) `cmd` implementation.
  */
 class CommandManager {
-private:
+  private:
     /** List of registered commands, mapped by their (unique) name. */
     static std::map<std::string, ConsoleCommand*> commands;
 
-private:
+  private:
     /** Splits the given string into space delimited tokens. */
     static std::vector<std::string> TokenizeString(const std::string& input);
 
-public:
+  public:
     /** Adds a command with the given name and the given callback to be available in the console. */
     static ConsoleCommand* Add(std::string name, CommandHandler function);
     // static void Remove(ConsoleCommand* cmd);

--- a/Console/Console.cpp
+++ b/Console/Console.cpp
@@ -7,30 +7,28 @@
 #include "CommandManager.h"
 #include "VariableManager.h"
 
-#include "../utils/utils.h"
-#include "../irender.h"
-#include "../r_font.h"
 #include "../hkd_interface.h"
 #include "../input.h"
+#include "../irender.h"
+#include "../r_font.h"
+#include "../utils/utils.h"
 
-
-ConsoleVariable con_stdout = {"con_stdout", 1};
-ConsoleVariable con_scroll = {"con_scroll", 1};
-
+ConsoleVariable con_stdout = { "con_stdout", 1 };
+ConsoleVariable con_scroll = { "con_scroll", 1 };
 
 Console* Console::instance = nullptr;
 
-Console::Console(int lineBufferSize, int inputHistorySize) :
-    m_lineBuffer(lineBufferSize), 
-    m_inputHistory(inputHistorySize) {
+Console::Console(int lineBufferSize, int inputHistorySize)
+    : m_lineBuffer(lineBufferSize),
+      m_inputHistory(inputHistorySize) {
 
-        m_pConsoleFont = new CFont("fonts/HackNerdFont-Bold.ttf", 26);
-        IRender *renderer = GetRenderer();
-        renderer->RegisterFont(m_pConsoleFont);
+    m_pConsoleFont    = new CFont("fonts/HackNerdFont-Bold.ttf", 26);
+    IRender* renderer = GetRenderer();
+    renderer->RegisterFont(m_pConsoleFont);
 }
 
 Console* Console::Create(int lineBufferSize, int inputHistorySize) {
-    if (instance == nullptr) {
+    if ( instance == nullptr ) {
         instance = new Console(lineBufferSize, inputHistorySize);
         VariableManager::Register(&con_stdout);
         VariableManager::Register(&con_scroll);
@@ -39,8 +37,8 @@ Console* Console::Create(int lineBufferSize, int inputHistorySize) {
 }
 
 const Console* Console::Instance() {
-    assert( instance != nullptr );
-    
+    assert(instance != nullptr);
+
     return instance;
 }
 
@@ -49,13 +47,13 @@ int Console::ScrollPos() {
 }
 
 void Console::Scroll(int delta) {
-    if (!con_scroll.value) return;
+    if ( !con_scroll.value ) return;
 
     m_scrollPos += delta;
 
-    if (m_scrollPos >= m_lineBuffer.Size()) {
+    if ( m_scrollPos >= m_lineBuffer.Size() ) {
         m_scrollPos = m_lineBuffer.Size() - 1;
-    } else if (m_scrollPos < 0) {
+    } else if ( m_scrollPos < 0 ) {
         m_scrollPos = 0;
     }
 }
@@ -67,9 +65,9 @@ int Console::CursorPos() {
 void Console::MoveCursor(int delta) {
     m_cursorPos += delta;
 
-    if (m_cursorPos > (int)m_currentInput.length()) {
+    if ( m_cursorPos > (int)m_currentInput.length() ) {
         m_cursorPos = m_currentInput.length();
-    } else if (m_cursorPos < 0) {
+    } else if ( m_cursorPos < 0 ) {
         m_cursorPos = 0;
     }
     m_blinkTimer = 0;
@@ -81,21 +79,21 @@ std::string Console::CurrentInput() {
 
 void Console::SetInput(std::string input) {
     m_currentInput = input;
-    m_cursorPos = input.length();
-    m_blinkTimer = 0;
+    m_cursorPos    = input.length();
+    m_blinkTimer   = 0;
 }
 
 void Console::SetInputFromHistory(int delta) {
-    if (delta == 0 || m_inputHistory.Size() == 0) return;
+    if ( delta == 0 || m_inputHistory.Size() == 0 ) return;
     m_inputHistoryPos += delta;
 
-    if (m_inputHistoryPos >= m_inputHistory.Size()) {
+    if ( m_inputHistoryPos >= m_inputHistory.Size() ) {
         m_inputHistoryPos = m_inputHistory.Size() - 1;
-    } else if (m_inputHistoryPos < -1) {
+    } else if ( m_inputHistoryPos < -1 ) {
         m_inputHistoryPos = -1;
     }
     std::string str = "";
-    if (m_inputHistoryPos > -1) {
+    if ( m_inputHistoryPos > -1 ) {
         m_inputHistory.Get(m_inputHistoryPos, &str);
     }
     SetInput(str);
@@ -108,7 +106,7 @@ void Console::UpdateInput(std::string substr) {
 }
 
 void Console::DeleteInput(int delta) {
-    if (delta < 0) {
+    if ( delta < 0 ) {
         int prevCursorPos = m_cursorPos;
         MoveCursor(delta);
         int eraseCount = prevCursorPos - m_cursorPos;
@@ -122,13 +120,13 @@ void Console::DeleteInput(int delta) {
 void Console::SubmitInput() {
     Print(m_currentInput);
     m_inputHistoryPos = -1;
-    m_cursorPos = 0;
-    m_scrollPos = 0;
-    m_blinkTimer = 0;
+    m_cursorPos       = 0;
+    m_scrollPos       = 0;
+    m_blinkTimer      = 0;
 
-    if (m_currentInput == "") return;
+    if ( m_currentInput == "" ) return;
     std::string lastInput;
-    if (!m_inputHistory.Get(0, &lastInput) || lastInput != m_currentInput) {
+    if ( !m_inputHistory.Get(0, &lastInput) || lastInput != m_currentInput ) {
         m_inputHistory.Push(m_currentInput);
     }
     CommandManager::ExecuteString(m_currentInput);
@@ -136,7 +134,7 @@ void Console::SubmitInput() {
 }
 
 void Console::Print(std::string str) {
-    if (con_stdout.value) {
+    if ( con_stdout.value ) {
         printf("%s\n", str.c_str());
     }
     instance->m_lineBuffer.Push(str);
@@ -147,13 +145,13 @@ void Console::PrintfImpl(const char* fmt, ...) {
     va_start(args, fmt);
     va_list argsCpy;
     va_copy(argsCpy, args);
-    int argsSize = vsnprintf(NULL, 0, fmt, args) + 1;
-    char* buffer = (char*)malloc( argsSize );
+    int   argsSize = vsnprintf(NULL, 0, fmt, args) + 1;
+    char* buffer   = (char*)malloc(argsSize);
     va_end(args);
-    vsnprintf(buffer, argsSize, fmt, argsCpy); 
+    vsnprintf(buffer, argsSize, fmt, argsCpy);
     va_end(argsCpy);
 
-    if (con_stdout.value) {
+    if ( con_stdout.value ) {
         printf("%s\n", buffer);
     }
     instance->m_lineBuffer.Push(std::string(buffer));
@@ -164,29 +162,28 @@ void Console::PrintfImpl(const char* fmt, ...) {
 void Console::RunFrame() {
     float msPerFrame = (float)GetDeltaTime();
     m_blinkTimer += msPerFrame;
-    if (TextInput().length()) {
+    if ( TextInput().length() ) {
         UpdateInput(TextInput());
-    } else if (GetMouseWheel().updated) {
+    } else if ( GetMouseWheel().updated ) {
         Scroll(GetMouseWheel().current.y);
-    } else if (KeyWentDownUnbuffered(SDLK_UP)) { 
+    } else if ( KeyWentDownUnbuffered(SDLK_UP) ) {
         SetInputFromHistory(1);
-    } else if (KeyWentDownUnbuffered(SDLK_DOWN)) {
+    } else if ( KeyWentDownUnbuffered(SDLK_DOWN) ) {
         SetInputFromHistory(-1);
-    } else if (KeyWentDownUnbuffered(SDLK_LEFT)) {
+    } else if ( KeyWentDownUnbuffered(SDLK_LEFT) ) {
         MoveCursor(-1);
-    } else if (KeyWentDownUnbuffered(SDLK_RIGHT)) {
+    } else if ( KeyWentDownUnbuffered(SDLK_RIGHT) ) {
         MoveCursor(1);
-    } else if (KeyWentDownUnbuffered(SDLK_BACKSPACE)) {
+    } else if ( KeyWentDownUnbuffered(SDLK_BACKSPACE) ) {
         DeleteInput(-1);
-    } else if (KeyWentDownUnbuffered(SDLK_DELETE)) {
+    } else if ( KeyWentDownUnbuffered(SDLK_DELETE) ) {
         DeleteInput(1);
-    } else if (KeyWentDown(SDLK_RETURN)) {
+    } else if ( KeyWentDown(SDLK_RETURN) ) {
         SubmitInput();
     }
-    
+
     IRender* renderer = GetRenderer();
     //renderer->RenderBegin();
     renderer->RenderConsole(this, m_pConsoleFont);
     //renderer->RenderEnd();
 }
-

--- a/Console/Console.h
+++ b/Console/Console.h
@@ -13,7 +13,7 @@
  * Implemented as a singleton for printing support, use `Console::Create` instead of the constructor.
  */
 class Console {
-private:
+  private:
     /** The current (editable) input string. */
     std::string m_currentInput = "";
     /** Current position in the history to use for replacing the current input. `-1` indicates current/empty input. */
@@ -25,13 +25,13 @@ private:
     /** Font to draw characters with. Must be initialized in Create() */
     CFont* m_pConsoleFont = nullptr;
 
-private:
+  private:
     /** The singleton instance of the console. */
     static Console* instance;
     /** Create/initialize the console and its buffers, etc. */
     Console(int lineBufferSize, int inputHistorySize);
 
-public:
+  public:
     /** Buffer for storing the lines written to the console. */
     CircularBuffer m_lineBuffer;
     /** Buffer for storing the executed command/input history. */
@@ -41,8 +41,8 @@ public:
     /** Milliseconds since last cursor blink cycle. */
     double m_blinkTimer = 0;
 
-public:
-    Console(const Console &obj) = delete; // delete copy constructor
+  public:
+    Console(const Console& obj) = delete; // delete copy constructor
 
     /** Create the console (singleton) instance and initialize it and its buffers, etc. */
     static Console* Create(int lineBufferSize, int inputHistorySize);
@@ -72,24 +72,27 @@ public:
     /** Activate Console, receive input and render. */
     void RunFrame();
 
-
-public:
+  public:
     /** Prints the given string to the console as a line. */
     static void Print(std::string str);
     /** Formats and prints the given string to the console as a line. */
-    template<typename... Args>
-    static void Printf(std::string fmt, Args const&... args) { // implementation must be in header due to variadic template
+    template <typename... Args>
+    static void Printf(std::string fmt,
+                       Args const&... args) { // implementation must be in header due to variadic template
         PrintfImpl(fmt.c_str(), convertArg(args)...);
     }
 
-private:
+  private:
     /** C-style implementation for formatting the given string and printing it to the console. */
     static void PrintfImpl(const char* fmt, ...);
     /** Helper function to convert the variadic argument list to be printf compatible. */
-    template<typename T>
-    static decltype(auto) convertArg(T const& arg) { return arg; }
+    template <typename T> static decltype(auto) convertArg(T const& arg) {
+        return arg;
+    }
     /** Helper function to convert the variadic argument list to be printf compatible. `std::string` is converted to c strings. */
-    static const char* convertArg(std::string const& arg) { return arg.c_str(); }
+    static const char* convertArg(std::string const& arg) {
+        return arg.c_str();
+    }
 };
 
 #endif // CONSOLE_H

--- a/Console/VariableManager.cpp
+++ b/Console/VariableManager.cpp
@@ -2,19 +2,17 @@
 
 #include <stdlib.h>
 
+#include "../utils/utils.h"
 #include "CommandManager.h"
 #include "Console.h"
-#include "../utils/utils.h"
-
 
 void Reset_f(std::vector<std::string> args) {
-    if (args.size() == 2) {
-        VariableManager::Reset(args[1]);
+    if ( args.size() == 2 ) {
+        VariableManager::Reset(args[ 1 ]);
     } else {
         Console::Print("Invalid number of arguments to reset variable!");
     }
 }
-
 
 std::map<std::string, ConsoleVariable*> VariableManager::m_Variables;
 
@@ -23,13 +21,13 @@ void VariableManager::Init() {
 }
 
 bool VariableManager::Register(ConsoleVariable* var) {
-    if (CommandManager::Find(var->name)) {
+    if ( CommandManager::Find(var->name) ) {
         Console::Printf("Can't register variable, '%s' is a command.", var->name);
         return false;
     }
 
-    bool inserted = m_Variables.insert({var->name, var}).second;
-    if (!inserted) {
+    bool inserted = m_Variables.insert({ var->name, var }).second;
+    if ( !inserted ) {
         Console::Printf("Can't register variable %s, already defined.", var->name);
         return false;
     }
@@ -37,15 +35,16 @@ bool VariableManager::Register(ConsoleVariable* var) {
 }
 
 bool VariableManager::RegisterAlias(ConsoleVariable* var, std::string alias) {
-    if (CommandManager::Find(alias)) {
+    if ( CommandManager::Find(alias) ) {
         Console::Printf("Can't register variable with alias, '%s' is a command.", alias);
         return false;
-    } else if (Find(var->name) != var) {
-        Console::Printf("Can't register variable with alias '%s', variable '%s' not registered properly.", alias, var->name);
+    } else if ( Find(var->name) != var ) {
+        Console::Printf(
+            "Can't register variable with alias '%s', variable '%s' not registered properly.", alias, var->name);
         return false;
     }
-    bool inserted = m_Variables.insert({alias, var}).second;
-    if (!inserted) {
+    bool inserted = m_Variables.insert({ alias, var }).second;
+    if ( !inserted ) {
         Console::Printf("Can't register variable with alias %s, already defined.", alias);
         return false;
     }
@@ -54,9 +53,9 @@ bool VariableManager::RegisterAlias(ConsoleVariable* var, std::string alias) {
 
 ConsoleVariable* VariableManager::Create(std::string name, float value) {
     ConsoleVariable* var = Find(name);
-    if (var) {
+    if ( var ) {
         return var;
-    } else if (CommandManager::Exists(name)) {
+    } else if ( CommandManager::Exists(name) ) {
         Console::Printf("Can't create variable, '%s' is a command.", name);
         return nullptr;
     }
@@ -76,7 +75,7 @@ bool VariableManager::Exists(std::string name) {
 
 void VariableManager::Set(std::string name, float value) {
     ConsoleVariable* var = Find(name);
-    if (!var) {
+    if ( !var ) {
         Console::Printf("Variable '%s' not found.", name);
         return;
     }
@@ -90,7 +89,7 @@ void VariableManager::Set(ConsoleVariable* var, float value) {
 
 void VariableManager::Reset(std::string name) {
     ConsoleVariable* var = Find(name);
-    if (!var) {
+    if ( !var ) {
         Console::Printf("Variable '%s' not found.", name);
         return;
     }
@@ -98,25 +97,25 @@ void VariableManager::Reset(std::string name) {
 }
 
 bool VariableManager::HandleCommand(std::vector<std::string> args) {
-    ConsoleVariable* var = Find(args[0]);
-    if (!var) return false; // TODO: also match substrings and show all matching variables?
-        
-    if (args.size() == 1) { // print variable info
-        std::string fmt = "Variable '%s' is %.*f";
-        int decimals = var->value == 0 || var->value == 1 ? 0 : 2;
-        if (var->value == var->defaultValue) {
-            Console::Printf(fmt + " (default)", args[0], decimals, var->value);
+    ConsoleVariable* var = Find(args[ 0 ]);
+    if ( !var ) return false; // TODO: also match substrings and show all matching variables?
+
+    if ( args.size() == 1 ) { // print variable info
+        std::string fmt      = "Variable '%s' is %.*f";
+        int         decimals = var->value == 0 || var->value == 1 ? 0 : 2;
+        if ( var->value == var->defaultValue ) {
+            Console::Printf(fmt + " (default)", args[ 0 ], decimals, var->value);
         } else {
             int defaultDecimals = var->defaultValue == 0 || var->defaultValue == 1 ? 0 : 2;
-            Console::Printf(fmt + " (default: %.*f)", args[0], decimals, var->value, defaultDecimals, var->defaultValue);
+            Console::Printf(
+                fmt + " (default: %.*f)", args[ 0 ], decimals, var->value, defaultDecimals, var->defaultValue);
         }
-    } else if (args.size() == 2) { // set variable
-        std::string argString = args[1];
+    } else if ( args.size() == 2 ) { // set variable
+        std::string argString = args[ 1 ];
         if ( !IsStringFloat(argString) ) {
             Console::Printf("Can't set variable, invalid value '%s'.", argString);
-        }
-        else {
-            float newVal = atof( argString.c_str() );
+        } else {
+            float newVal = atof(argString.c_str());
             Set(var, newVal);
         }
     } else {

--- a/Console/VariableManager.h
+++ b/Console/VariableManager.h
@@ -7,12 +7,15 @@
 
 struct ConsoleVariable {
     const std::string name;
-    const float defaultValue;
-    float value;
+    const float       defaultValue;
+    float             value;
     // TODO: maybe store entered value string (like quake) to avoid formatting issues for printing (esp. with floats)? see `HandleCommand()`.
     // TODO: optionally store min/max value (and maybe stepsize?) for input validation?
     // TODO: add description / help text for console help?
-    ConsoleVariable(std::string n, float v) : name(n), defaultValue(v), value(v) {}
+    ConsoleVariable(std::string n, float v)
+        : name(n),
+          defaultValue(v),
+          value(v) {}
 };
 
 /**
@@ -20,11 +23,11 @@ struct ConsoleVariable {
  * Loosely based on Quake's (QSS-M) `cvar` implementation.
  */
 class VariableManager {
-private:
+  private:
     /** List of registered variables, mapped by their (unique) name. */
     static std::map<std::string, ConsoleVariable*> m_Variables;
 
-public:
+  public:
     /** Initialize VariableManager variables / commands. */
     static void Init();
     /** Registers the given variable to be available in the console. */
@@ -54,4 +57,3 @@ public:
 };
 
 #endif // VARIABLEMANAGER_H
-

--- a/Entity/Door/g_door.cpp
+++ b/Entity/Door/g_door.cpp
@@ -7,26 +7,25 @@
 #include <SDL.h>
 
 #define GLM_FORCE_RADIANS
-#include "../../dependencies/glm/glm.hpp"
 #include "../../dependencies/glm/ext.hpp"
+#include "../../dependencies/glm/glm.hpp"
 #include "../../dependencies/glm/gtx/quaternion.hpp"
 
-#include "g_door_states.h"
+#include "../../globals.h"
+#include "../../hkd_interface.h"
 #include "../../map_parser.h"
 #include "../../polysoup.h"
 #include "../../r_common.h"
-#include "../../hkd_interface.h"
 #include "../../r_model.h"
-#include "../../globals.h"
+#include "g_door_states.h"
 
 void Door::Update() {
     m_pStateMachine->Update();
 }
 
-Door::Door(const std::vector<Property>& properties, 
-           const std::vector<Brush>& brushes) : 
-    BaseGameEntity(ET_DOOR),
-    m_pStateMachine(nullptr) {
+Door::Door(const std::vector<Property>& properties, const std::vector<Brush>& brushes)
+    : BaseGameEntity(ET_DOOR),
+      m_pStateMachine(nullptr) {
 
     m_pStateMachine = new StateMachine(this);
     m_pStateMachine->SetCurrentState(DoorClosed::Instance());
@@ -37,47 +36,41 @@ Door::Door(const std::vector<Property>& properties,
     BaseGameEntity::GetProperty<int>(properties, "lip", &m_Lip);
 
     // Load the model from brushes
-    m_Model = CreateModelFromBrushes( brushes );
+    m_Model           = CreateModelFromBrushes(brushes);
     IRender* renderer = GetRenderer();
     renderer->RegisterBrush(&m_Model);
 
     // Get the brush (geometry) that defines this door
     // Assume just one brush for now... // TODO: Could be more brushes!
-    std::vector<MapPolygon> mapPolys = createPolysoup( brushes[ 0 ] );
-    std::vector<MapPolygon> mapTris = triangulate(mapPolys);
-   
+    std::vector<MapPolygon> mapPolys = createPolysoup(brushes[ 0 ]);
+    std::vector<MapPolygon> mapTris  = triangulate(mapPolys);
+
     // NOTE: Just make doors golden for now. Obviously we texture them later.
     // TODO: This stuff happens quite common. Also: Maybe tris are sufficient?
-    glm::vec4 triColor = glm::vec4(1.0f, 0.9f, 0.0f, 1.0f); 
-    glm::vec3 mins = glm::vec3(99999.0f);
-    glm::vec3 maxs = glm::vec3(-99999.0f);
-    for (int i = 0; i < mapTris.size(); i++) {
+    glm::vec4 triColor = glm::vec4(1.0f, 0.9f, 0.0f, 1.0f);
+    glm::vec3 mins     = glm::vec3(99999.0f);
+    glm::vec3 maxs     = glm::vec3(-99999.0f);
+    for ( int i = 0; i < mapTris.size(); i++ ) {
 
         MapPolygon mapPoly = mapTris[ i ];
-        
-        Vertex A = { glm::vec3(mapPoly.vertices[0].pos.x,
-                               mapPoly.vertices[0].pos.y,
-                               mapPoly.vertices[0].pos.z) };
-        Vertex B = { glm::vec3(mapPoly.vertices[1].pos.x, 
-                               mapPoly.vertices[1].pos.y,
-                               mapPoly.vertices[1].pos.z) };
-        Vertex C = { glm::vec3(mapPoly.vertices[2].pos.x, 
-                               mapPoly.vertices[2].pos.y, 
-                               mapPoly.vertices[2].pos.z) };
 
-        float minX = glm::min( A.pos.x, B.pos.x, C.pos.x );
-        float minY = glm::min( A.pos.y, B.pos.y, C.pos.y );
-        float minZ = glm::min( A.pos.z, B.pos.z, C.pos.z );
-        float maxX = glm::max( A.pos.x, B.pos.x, C.pos.x );
-        float maxY = glm::max( A.pos.y, B.pos.y, C.pos.y );
-        float maxZ = glm::max( A.pos.z, B.pos.z, C.pos.z );
+        Vertex A = { glm::vec3(mapPoly.vertices[ 0 ].pos.x, mapPoly.vertices[ 0 ].pos.y, mapPoly.vertices[ 0 ].pos.z) };
+        Vertex B = { glm::vec3(mapPoly.vertices[ 1 ].pos.x, mapPoly.vertices[ 1 ].pos.y, mapPoly.vertices[ 1 ].pos.z) };
+        Vertex C = { glm::vec3(mapPoly.vertices[ 2 ].pos.x, mapPoly.vertices[ 2 ].pos.y, mapPoly.vertices[ 2 ].pos.z) };
 
-        mins = glm::min( mins, glm::vec3(minX, minY, minZ) );
-        maxs = glm::max( maxs, glm::vec3(maxX, maxY, maxZ) );
+        float minX = glm::min(A.pos.x, B.pos.x, C.pos.x);
+        float minY = glm::min(A.pos.y, B.pos.y, C.pos.y);
+        float minZ = glm::min(A.pos.z, B.pos.z, C.pos.z);
+        float maxX = glm::max(A.pos.x, B.pos.x, C.pos.x);
+        float maxY = glm::max(A.pos.y, B.pos.y, C.pos.y);
+        float maxZ = glm::max(A.pos.z, B.pos.z, C.pos.z);
 
-        A.color = triColor;
-        B.color = triColor;
-        C.color = triColor;
+        mins = glm::min(mins, glm::vec3(minX, minY, minZ));
+        maxs = glm::max(maxs, glm::vec3(maxX, maxY, maxZ));
+
+        A.color    = triColor;
+        B.color    = triColor;
+        C.color    = triColor;
         MapTri tri = { A, B, C };
 
         m_MapTris.push_back(tri);
@@ -88,25 +81,22 @@ Door::Door(const std::vector<Property>& properties,
 
     // Distance to travel is the width of the door in the travel direction.
     glm::quat qDir;
-    if (m_Angle == -1 ) { // Door moves upward
-        qDir = glm::angleAxis( glm::radians(-90.0f), DOD_WORLD_FORWARD ); 
-    }
-    else if (m_Angle == -2) { // Door moves downward
-        qDir = glm::angleAxis( glm::radians(90.0f), DOD_WORLD_FORWARD ); 
-    }
-    else {
-        qDir = glm::angleAxis( glm::radians((float)m_Angle), DOD_WORLD_UP );
+    if ( m_Angle == -1 ) { // Door moves upward
+        qDir = glm::angleAxis(glm::radians(-90.0f), DOD_WORLD_FORWARD);
+    } else if ( m_Angle == -2 ) { // Door moves downward
+        qDir = glm::angleAxis(glm::radians(90.0f), DOD_WORLD_FORWARD);
+    } else {
+        qDir = glm::angleAxis(glm::radians((float)m_Angle), DOD_WORLD_UP);
     }
 
-    m_Direction = glm::rotate( qDir, m_Direction );
+    m_Direction = glm::rotate(qDir, m_Direction);
 
     // Compute distance to travel
-    glm::vec3 minsToMaxs = maxs - mins;
+    glm::vec3 minsToMaxs     = maxs - mins;
     glm::vec3 directedLength = m_Direction * minsToMaxs;
-    m_Distance = glm::length(directedLength) - (double)m_Lip;
+    m_Distance               = glm::length(directedLength) - (double)m_Lip;
 }
 
 bool Door::HandleMessage(const Telegram& telegram) {
     return m_pStateMachine->HandleMessage(telegram);
 }
-

--- a/Entity/Door/g_door.h
+++ b/Entity/Door/g_door.h
@@ -10,14 +10,13 @@
 #include "../../Clock/clock.h"
 #include "../../FSM/state_machine.h"
 #include "../../Message/message_dispatcher.h"
-#include "../base_game_entity.h"
 #include "../../map_parser.h"
 #include "../../r_common.h"
 #include "../../r_model.h"
+#include "../base_game_entity.h"
 
 class Door : public BaseGameEntity {
-private:
-
+  private:
     StateMachine<Door>* m_pStateMachine;
 
     // TODO: I don't think that a door should hold on
@@ -32,10 +31,9 @@ private:
 
     HKD_Model m_Model;
 
-public:
-
+  public:
     explicit Door(const std::vector<Property>& properties, const std::vector<Brush>& brushes);
-    
+
     void Update() override;
 
     ~Door() override {
@@ -84,4 +82,3 @@ public:
 };
 
 #endif // _DOOR_H_
-

--- a/Entity/Door/g_door_states.cpp
+++ b/Entity/Door/g_door_states.cpp
@@ -4,9 +4,9 @@
 
 #include "g_door_states.h"
 
-#include "../../utils/utils.h"
-#include "../../r_model.h"
 #include "../../CWorld.h"
+#include "../../r_model.h"
+#include "../../utils/utils.h"
 #include "../Message/message_type.h"
 #include <stdio.h>
 
@@ -68,16 +68,15 @@ void DoorOpening::Execute(Door* pDoor) {
     // to variations of the deltaTime and floating
     // point rounding errors.
 
-    double distance = glm::clamp(pDoor->m_Speed * GetDeltaTime() / 1000.0,
-                                0.0, pDoor->m_Distance);
+    double distance = glm::clamp(pDoor->m_Speed * GetDeltaTime() / 1000.0, 0.0, pDoor->m_Distance);
 
     // Open the door.
-    
+
     // Move the render representation.
     HKD_Model* doorModel = pDoor->GetModel();
-    glm::vec3 travel =  (float)distance * pDoor->m_Direction;
+    glm::vec3  travel    = (float)distance * pDoor->m_Direction;
     doorModel->position += travel;
-  
+
     // Move the CPU side representation for collision.
     std::vector<MapTri>& mapTris = pDoor->MapTris();
     for ( int i = 0; i < mapTris.size(); i++ ) {
@@ -87,7 +86,7 @@ void DoorOpening::Execute(Door* pDoor) {
             v.pos += travel;
         }
     }
-    
+
     // Check if door has reached its opened state.
     // If so switch to the opened state.
     pDoor->m_CurrentDistance += distance;

--- a/Entity/Door/g_door_states.h
+++ b/Entity/Door/g_door_states.h
@@ -42,7 +42,7 @@ class DoorOpening : public State<Door> {
     bool OnMessage(Door* agent, const Telegram& telegram) override;
 };
 
-class DoorOpened: public State<Door> {
+class DoorOpened : public State<Door> {
   private:
     DoorOpened() = default;
     // copy ctor and assignment should be private
@@ -59,5 +59,3 @@ class DoorOpened: public State<Door> {
     bool OnMessage(Door* agent, const Telegram& telegram) override;
 };
 #endif // _DOOR_STATES_H_
-
-

--- a/Entity/Enemy/g_enemy.cpp
+++ b/Entity/Enemy/g_enemy.cpp
@@ -13,11 +13,11 @@
 #include "../../dependencies/glm/gtx/quaternion.hpp"
 #include "../../dependencies/glm/gtx/vector_angle.hpp"
 
+#include "../../globals.h"
 #include "../../input.h"
 #include "../../input_handler.h"
 #include "../../utils/quick_math.h"
 #include "../../utils/utils.h"
-#include "../../globals.h"
 #include "g_enemy_states.h"
 
 Enemy::Enemy(const std::vector<Property>& properties)
@@ -26,14 +26,14 @@ Enemy::Enemy(const std::vector<Property>& properties)
       m_EllipsoidCollider() {
     m_pStateMachine = new StateMachine(this);
     m_pStateMachine->SetCurrentState(EnemyIdle::Instance());
-   
+
     // We want position and, if applicable, a target.
     BaseGameEntity::GetProperty<glm::vec3>(properties, "origin", &m_Position);
     // FIX: Mem Leak on exit if target is not being set.
     BaseGameEntity::GetProperty<std::string>(properties, "target", &m_Target);
 
     LoadModel("models/multiple_anims/multiple_anims.iqm", m_Position);
-    m_Velocity = glm::vec3(0.0f, 0.0f, 0.0f);
+    m_Velocity           = glm::vec3(0.0f, 0.0f, 0.0f);
     m_pSteeringBehaviour = new SteeringBehaviour(this);
     // m_pSteeringBehaviour->WanderOn();
 }

--- a/Entity/Enemy/g_enemy.h
+++ b/Entity/Enemy/g_enemy.h
@@ -25,9 +25,9 @@ class Enemy : public MovingEntity {
     ~Enemy() override {
         delete m_pStateMachine;
         delete m_pSteeringBehaviour;
-        delete m_Path; 
+        delete m_Path;
     }
-   
+
     [[nodiscard]] StateMachine<Enemy>* GetFSM() const {
         return m_pStateMachine;
     }

--- a/Entity/Enemy/g_enemy_states.cpp
+++ b/Entity/Enemy/g_enemy_states.cpp
@@ -7,70 +7,70 @@
 #include "g_enemy.h"
 #include <stdio.h>
 
-EnemyIdle *EnemyIdle::Instance() {
+EnemyIdle* EnemyIdle::Instance() {
     static EnemyIdle instance;
 
     return &instance;
 }
 
-void EnemyIdle::Enter(Enemy *pEnemy) { 
-    //printf("Enemy entered Idle State\n"); 
+void EnemyIdle::Enter(Enemy* pEnemy) {
+    //printf("Enemy entered Idle State\n");
 }
 
-void EnemyIdle::Execute(Enemy *pEnemy) { 
-    //printf("Enemy is executing Idle State\n"); 
+void EnemyIdle::Execute(Enemy* pEnemy) {
+    //printf("Enemy is executing Idle State\n");
 }
 
-void EnemyIdle::Exit(Enemy *pEnemy) {
-    //printf("Enemy is exiting Idle State\n"); 
+void EnemyIdle::Exit(Enemy* pEnemy) {
+    //printf("Enemy is exiting Idle State\n");
 }
 
-bool EnemyIdle::OnMessage(Enemy *agent, const Telegram &telegram) {
+bool EnemyIdle::OnMessage(Enemy* agent, const Telegram& telegram) {
     //printf("\nEnemy received telegram %s\n", MessageToString(telegram.Message).c_str());
 
-    switch (telegram.Message) {
-        case message_type::Attack: {
-            agent->DecreaseHealth(*(double *)telegram.ExtraInfo * 2.0);
-            if (agent->IsDead()) {
-                agent->GetFSM()->ChangeState(EnemyDead::Instance());
-                return true;
-            }
-
-            agent->GetFSM()->ChangeState(EnemyAttacking::Instance());
-
+    switch ( telegram.Message ) {
+    case message_type::Attack: {
+        agent->DecreaseHealth(*(double*)telegram.ExtraInfo * 2.0);
+        if ( agent->IsDead() ) {
+            agent->GetFSM()->ChangeState(EnemyDead::Instance());
             return true;
-        } break;
-        default: {
-            return false;
         }
+
+        agent->GetFSM()->ChangeState(EnemyAttacking::Instance());
+
+        return true;
+    } break;
+    default: {
+        return false;
+    }
     }
 }
 
-EnemyAttacking *EnemyAttacking::Instance() {
+EnemyAttacking* EnemyAttacking::Instance() {
     static EnemyAttacking instance;
 
     return &instance;
 }
 
-void EnemyAttacking::Enter(Enemy *pEnemy) { 
-    //printf("Enemy entered Attacking State\n"); 
+void EnemyAttacking::Enter(Enemy* pEnemy) {
+    //printf("Enemy entered Attacking State\n");
 }
 
-void EnemyAttacking::Execute(Enemy *pEnemy) { 
-    //printf("Enemy is executing Attacking State\n"); 
+void EnemyAttacking::Execute(Enemy* pEnemy) {
+    //printf("Enemy is executing Attacking State\n");
 }
 
-void EnemyAttacking::Exit(Enemy *pEnemy) { 
-    //printf("Player is exiting Attacking State\n"); 
+void EnemyAttacking::Exit(Enemy* pEnemy) {
+    //printf("Player is exiting Attacking State\n");
 }
 
-bool EnemyAttacking::OnMessage(Enemy *agent, const Telegram &telegram) {
+bool EnemyAttacking::OnMessage(Enemy* agent, const Telegram& telegram) {
     printf("\nEnemy received telegram %s\n", MessageToString(telegram.Message).c_str());
-    switch (telegram.Message) {
+    switch ( telegram.Message ) {
     case message_type::Attack: {
-        agent->DecreaseHealth(*(double *)telegram.ExtraInfo);
+        agent->DecreaseHealth(*(double*)telegram.ExtraInfo);
 
-        if (agent->IsDead()) {
+        if ( agent->IsDead() ) {
             agent->GetFSM()->ChangeState(EnemyDead::Instance());
             return true;
         }
@@ -81,22 +81,22 @@ bool EnemyAttacking::OnMessage(Enemy *agent, const Telegram &telegram) {
         return false;
     }
 }
-EnemyDead *EnemyDead::Instance() {
+EnemyDead* EnemyDead::Instance() {
     static EnemyDead instance;
 
     return &instance;
 }
 
-void EnemyDead::Enter(Enemy *pEnemy) { 
-    //printf("Enemy entered Dead State\n"); 
+void EnemyDead::Enter(Enemy* pEnemy) {
+    //printf("Enemy entered Dead State\n");
 }
 
-void EnemyDead::Execute(Enemy *pEnemy) { 
-    //printf("Enemy is executing Dead State\n"); 
+void EnemyDead::Execute(Enemy* pEnemy) {
+    //printf("Enemy is executing Dead State\n");
 }
 
-void EnemyDead::Exit(Enemy *pEnemy) { 
-    //printf("Player is exiting Dead State\n"); 
+void EnemyDead::Exit(Enemy* pEnemy) {
+    //printf("Player is exiting Dead State\n");
 }
 
 bool EnemyDead::OnMessage(Enemy* agent, const Telegram& telegram) {
@@ -129,7 +129,7 @@ void EnemyWander::Exit(Enemy* pEnemy) {
 }
 
 bool EnemyWander::OnMessage(Enemy* agent, const Telegram& telegram) {
-    return false; 
+    return false;
 }
 
 // ---------------------------------

--- a/Entity/Enemy/g_enemy_states.h
+++ b/Entity/Enemy/g_enemy_states.h
@@ -11,64 +11,64 @@ class Telegram;
 
 class EnemyIdle : public State<Enemy> {
   private:
-	EnemyIdle() = default;
-	// copy ctor and assignment should be private
-	EnemyIdle(const EnemyIdle&);
-	EnemyIdle& operator=(const EnemyIdle&);
+    EnemyIdle() = default;
+    // copy ctor and assignment should be private
+    EnemyIdle(const EnemyIdle&);
+    EnemyIdle& operator=(const EnemyIdle&);
 
   public:
-	// this is a singleton
-	static EnemyIdle* Instance();
+    // this is a singleton
+    static EnemyIdle* Instance();
 
-	void Enter(Enemy* pEnemy) override;
+    void Enter(Enemy* pEnemy) override;
 
-	void Execute(Enemy* pEnemy) override;
+    void Execute(Enemy* pEnemy) override;
 
-	void Exit(Enemy* pEnemy) override;
+    void Exit(Enemy* pEnemy) override;
 
-	bool OnMessage(Enemy* agent, const Telegram& telegram) override;
+    bool OnMessage(Enemy* agent, const Telegram& telegram) override;
 };
 
 class EnemyAttacking : public State<Enemy> {
   private:
-	EnemyAttacking() = default;
-	// copy ctor and assignment should be private
-	EnemyAttacking(const EnemyAttacking&);
-	EnemyAttacking& operator=(const EnemyAttacking&);
+    EnemyAttacking() = default;
+    // copy ctor and assignment should be private
+    EnemyAttacking(const EnemyAttacking&);
+    EnemyAttacking& operator=(const EnemyAttacking&);
 
   public:
-	// this is a singleton
-	static EnemyAttacking* Instance();
+    // this is a singleton
+    static EnemyAttacking* Instance();
 
-	void Enter(Enemy* pEnemy) override;
+    void Enter(Enemy* pEnemy) override;
 
-	void Execute(Enemy* pEnemy) override;
+    void Execute(Enemy* pEnemy) override;
 
-	void Exit(Enemy* pEnemy) override;
+    void Exit(Enemy* pEnemy) override;
 
-	bool OnMessage(Enemy* agent, const Telegram& telegram) override;
+    bool OnMessage(Enemy* agent, const Telegram& telegram) override;
 };
 
 class EnemyDead : public State<Enemy> {
   private:
-	EnemyDead() = default;
+    EnemyDead() = default;
 
-	// copy ctor and assignment should be private
-	EnemyDead(const EnemyDead&);
-	EnemyDead& operator=(const EnemyDead&);
+    // copy ctor and assignment should be private
+    EnemyDead(const EnemyDead&);
+    EnemyDead& operator=(const EnemyDead&);
 
   public:
-	// copy ctor and assignment should be private
-	// this is a singleton
-	static EnemyDead* Instance();
+    // copy ctor and assignment should be private
+    // this is a singleton
+    static EnemyDead* Instance();
 
-	void Enter(Enemy* pEnemy) override;
+    void Enter(Enemy* pEnemy) override;
 
-	void Execute(Enemy* pEnemy) override;
+    void Execute(Enemy* pEnemy) override;
 
-	void Exit(Enemy* pEnemy) override;
+    void Exit(Enemy* pEnemy) override;
 
-	bool OnMessage(Enemy* agent, const Telegram& telegram) override;
+    bool OnMessage(Enemy* agent, const Telegram& telegram) override;
 };
 
 class EnemyWander : public State<Enemy> {

--- a/Entity/FlyCamera/g_fly_camera.cpp
+++ b/Entity/FlyCamera/g_fly_camera.cpp
@@ -4,74 +4,67 @@
 #include "../../dependencies/glm/ext.hpp"
 #include "../../dependencies/glm/glm.hpp"
 
+#include "../../input.h"
 #include "../../input_handler.h"
 #include "../../input_receiver.h"
-#include "../../input.h"
 #include "../../utils/utils.h"
 
 CFlyCamera::CFlyCamera(glm::vec3 pos)
-	: BaseGameEntity(ET_FLY_CAMERA) {
+    : BaseGameEntity(ET_FLY_CAMERA) {
 
-	m_Camera = Camera(pos);
-	m_Position = pos;
+    m_Camera   = Camera(pos);
+    m_Position = pos;
 }
 
-CFlyCamera::~CFlyCamera() {
-}
+CFlyCamera::~CFlyCamera() {}
 
-void CFlyCamera::Update() {
-	
-}
+void CFlyCamera::Update() {}
 
 bool CFlyCamera::HandleMessage(const Telegram& telegram) {
-	return false;
+    return false;
 }
 
 void CFlyCamera::HandleInput() {
     ButtonState forward = CHECK_ACTION("forward");
-    ButtonState back	= CHECK_ACTION("back");
-    ButtonState left	= CHECK_ACTION("left");
-    ButtonState right	= CHECK_ACTION("right");
-    ButtonState look	= CHECK_ACTION("look");
+    ButtonState back    = CHECK_ACTION("back");
+    ButtonState left    = CHECK_ACTION("left");
+    ButtonState right   = CHECK_ACTION("right");
+    ButtonState look    = CHECK_ACTION("look");
 
-	float dt = (float)GetDeltaTime();
-	if (forward == ButtonState::PRESSED) {
-		m_Camera.Pan(dt*m_Camera.m_Forward);
-	}
-	if (back == ButtonState::PRESSED) {
-		m_Camera.Pan(dt*-m_Camera.m_Forward);
-	}
-	if (left == ButtonState::PRESSED) {
-		m_Camera.Pan(-dt*m_Camera.m_Side);
-	}
-	if (right == ButtonState::PRESSED) {
-		m_Camera.Pan(dt*m_Camera.m_Side);
-	}
+    float dt = (float)GetDeltaTime();
+    if ( forward == ButtonState::PRESSED ) {
+        m_Camera.Pan(dt * m_Camera.m_Forward);
+    }
+    if ( back == ButtonState::PRESSED ) {
+        m_Camera.Pan(dt * -m_Camera.m_Forward);
+    }
+    if ( left == ButtonState::PRESSED ) {
+        m_Camera.Pan(-dt * m_Camera.m_Side);
+    }
+    if ( right == ButtonState::PRESSED ) {
+        m_Camera.Pan(dt * m_Camera.m_Side);
+    }
 
-	if (look == ButtonState::WENT_DOWN) {
-		const MouseMotion mouseMotion = GetMouseMotion();
-		m_MouseX = mouseMotion.current.x;
-		m_MouseY = mouseMotion.current.y;
-	}
-	else if (look == ButtonState::PRESSED) {
-		const MouseMotion mouseMotion = GetMouseMotion();
-		m_MousePrevX = m_MouseX;
-		m_MousePrevY = m_MouseY;
-		m_MouseX = mouseMotion.current.x;
-		m_MouseY = mouseMotion.current.y;
-		int dX = m_MouseX - m_MousePrevX;
-		int dY = m_MouseY - m_MousePrevY;
-		m_Camera.RotateAroundUp( -dt*m_LookSpeed*(float)dX );	
-		m_Camera.RotateAroundSide( -dt*m_LookSpeed*(float)dY );
-	}
-	else if (look == ButtonState::WENT_UP) {
-		m_MouseX = 0;
-		m_MouseY = 0;
-		m_MousePrevX = 0;
-		m_MousePrevY = 0;
-	}
+    if ( look == ButtonState::WENT_DOWN ) {
+        const MouseMotion mouseMotion = GetMouseMotion();
+        m_MouseX                      = mouseMotion.current.x;
+        m_MouseY                      = mouseMotion.current.y;
+    } else if ( look == ButtonState::PRESSED ) {
+        const MouseMotion mouseMotion = GetMouseMotion();
+        m_MousePrevX                  = m_MouseX;
+        m_MousePrevY                  = m_MouseY;
+        m_MouseX                      = mouseMotion.current.x;
+        m_MouseY                      = mouseMotion.current.y;
+        int dX                        = m_MouseX - m_MousePrevX;
+        int dY                        = m_MouseY - m_MousePrevY;
+        m_Camera.RotateAroundUp(-dt * m_LookSpeed * (float)dX);
+        m_Camera.RotateAroundSide(-dt * m_LookSpeed * (float)dY);
+    } else if ( look == ButtonState::WENT_UP ) {
+        m_MouseX     = 0;
+        m_MouseY     = 0;
+        m_MousePrevX = 0;
+        m_MousePrevY = 0;
+    }
 
-	m_Position = m_Camera.m_Pos;
+    m_Position = m_Camera.m_Pos;
 }
-
-

--- a/Entity/FlyCamera/g_fly_camera.h
+++ b/Entity/FlyCamera/g_fly_camera.h
@@ -25,27 +25,23 @@
 */
 class CFlyCamera : public BaseGameEntity, public IInputReceiver {
 
-public:
+  public:
     CFlyCamera() = delete;
-    CFlyCamera(glm::vec3 pos = glm::vec3(0.0f)); 
+    CFlyCamera(glm::vec3 pos = glm::vec3(0.0f));
     ~CFlyCamera();
 
     void Update() override;
     bool HandleMessage(const Telegram& telegram) override;
     void HandleInput() override;
-    
-    Camera m_Camera;
-    float m_LookSpeed = 0.01f;
 
-private:
-	int m_MouseX = 0;
-	int m_MouseY = 0;
-	int m_MousePrevX = 0;
-	int m_MousePrevY = 0;
+    Camera m_Camera;
+    float  m_LookSpeed = 0.01f;
+
+  private:
+    int m_MouseX     = 0;
+    int m_MouseY     = 0;
+    int m_MousePrevX = 0;
+    int m_MousePrevY = 0;
 };
 
 #endif
-
-
-
-

--- a/Entity/FollowCamera/g_follow_camera.cpp
+++ b/Entity/FollowCamera/g_follow_camera.cpp
@@ -7,28 +7,27 @@
 CFollowCamera::CFollowCamera(BaseGameEntity* target)
     : BaseGameEntity(ET_CAMERA) {
 
-    assert( target != nullptr );
+    assert(target != nullptr);
 
-    m_Target = target;
+    m_Target   = target;
     m_Position = target->m_Position;
-    m_Camera = Camera(m_Position);
+    m_Camera   = Camera(m_Position);
     // FIX: The player model (target) was modeled to face to -y which
-    // is not the default! When we use actual models we should pay 
-    // attention to model our characters to face +y to not have to 
+    // is not the default! When we use actual models we should pay
+    // attention to model our characters to face +y to not have to
     // do fixes in code.
-    m_RotationAngle = 180.0f; 
+    m_RotationAngle = 180.0f;
 }
 
-CFollowCamera::~CFollowCamera() {
-}
+CFollowCamera::~CFollowCamera() {}
 
 void CFollowCamera::Update() {
-    glm::vec3 targetPos = m_Target->m_Position;
-    float rotationAngle = m_Target->m_RotationAngle;
+    glm::vec3 targetPos     = m_Target->m_Position;
+    float     rotationAngle = m_Target->m_RotationAngle;
 
     //printf("rotationAngle: %f\n", rotationAngle);
 
-    m_Camera.SetOrientationFromAngle(m_RotationAngle + rotationAngle, glm::vec3(0.0f, 0.0f, 1.0f) );
+    m_Camera.SetOrientationFromAngle(m_RotationAngle + rotationAngle, glm::vec3(0.0f, 0.0f, 1.0f));
     //m_Camera.RotateAroundUp(rotationAngle);
 
     // Set this entitiy's position based on target entity.
@@ -46,10 +45,9 @@ bool CFollowCamera::HandleMessage(const Telegram& telegram) {
 }
 
 void CFollowCamera::SetTarget(BaseGameEntity* target) {
-    assert( target != nullptr );
-    m_Target = target;
-    m_Position = target->m_Position;
+    assert(target != nullptr);
+    m_Target       = target;
+    m_Position     = target->m_Position;
     m_Camera.m_Pos = m_Position;
     printf("follow camera pos: %f, %f, %f\n", m_Position.x, m_Position.y, m_Position.z);
 }
-

--- a/Entity/FollowCamera/g_follow_camera.h
+++ b/Entity/FollowCamera/g_follow_camera.h
@@ -23,7 +23,7 @@
 */
 class CFollowCamera : public BaseGameEntity {
 
-public:
+  public:
     CFollowCamera(BaseGameEntity* target = nullptr);
     ~CFollowCamera();
 
@@ -34,10 +34,8 @@ public:
 
     Camera m_Camera;
 
-private:
+  private:
     BaseGameEntity* m_Target = nullptr;
 };
 
 #endif
-
-

--- a/Entity/Player/g_player.cpp
+++ b/Entity/Player/g_player.cpp
@@ -5,9 +5,9 @@
 #include "g_player.h"
 
 #include "../../input.h"
-#include "../../utils/utils.h"
 #include "../../input_handler.h"
 #include "../../input_receiver.h"
+#include "../../utils/utils.h"
 #include "g_player_states.h"
 
 #include <SDL.h>
@@ -28,8 +28,8 @@ Player::Player(glm::vec3 initialPosition)
 void Player::UpdatePosition(glm::vec3 newPosition) {
 
     // Update the ellipsoid colliders for all animation states based on the new collision position
-    for (int i = 0; i < m_Model.animations.size(); i++) {
-        m_Model.ellipsoidColliders[i].center = newPosition;
+    for ( int i = 0; i < m_Model.animations.size(); i++ ) {
+        m_Model.ellipsoidColliders[ i ].center = newPosition;
     }
     m_Model.position.x = newPosition.x;
     m_Model.position.y = newPosition.y;
@@ -61,18 +61,18 @@ void Player::LoadModel(const char* path, glm::vec3 initialPosition) {
     IQMModel iqmModel = LoadIQM(path);
 
     // Convert the model to our internal format
-    m_Model = CreateModelFromIQM(&iqmModel);
+    m_Model             = CreateModelFromIQM(&iqmModel);
     m_Model.isRigidBody = false;
-    m_Model.position = initialPosition;
-    m_Model.scale = glm::vec3(22.0f);
+    m_Model.position    = initialPosition;
+    m_Model.scale       = glm::vec3(22.0f);
 
     for ( int i = 0; i < m_Model.animations.size(); i++ ) {
         EllipsoidCollider* ec = &m_Model.ellipsoidColliders[ i ];
         ec->radiusA *= m_Model.scale.x;
         ec->radiusB *= m_Model.scale.z;
-        ec->center = m_Model.position + glm::vec3(0.0f, 0.0f, ec->radiusB);
+        ec->center      = m_Model.position + glm::vec3(0.0f, 0.0f, ec->radiusB);
         glm::vec3 scale = glm::vec3(1.0f / ec->radiusA, 1.0f / ec->radiusA, 1.0f / ec->radiusB);
-        ec->toESpace = glm::scale(glm::mat4(1.0f), scale);
+        ec->toESpace    = glm::scale(glm::mat4(1.0f), scale);
     }
 
     SetAnimState(&m_Model, ANIM_STATE_WALK);
@@ -97,18 +97,18 @@ void Player::UpdateCamera(Camera* camera) {
 }
 
 void Player::UpdatePlayerModel() {
-   
-    ButtonState forward = CHECK_ACTION("forward");
-    ButtonState back = CHECK_ACTION("back");
-    ButtonState left = CHECK_ACTION("left");
-    ButtonState right = CHECK_ACTION("right");
-    ButtonState speed = CHECK_ACTION("speed");
-    ButtonState turnLeft = CHECK_ACTION("turn_left");
+
+    ButtonState forward   = CHECK_ACTION("forward");
+    ButtonState back      = CHECK_ACTION("back");
+    ButtonState left      = CHECK_ACTION("left");
+    ButtonState right     = CHECK_ACTION("right");
+    ButtonState speed     = CHECK_ACTION("speed");
+    ButtonState turnLeft  = CHECK_ACTION("turn_left");
     ButtonState turnRight = CHECK_ACTION("turn_right");
-    
-    double dt = GetDeltaTime();
-    float followCamSpeed = 0.03f;
-    float followTurnSpeed = 0.3f;
+
+    double dt              = GetDeltaTime();
+    float  followCamSpeed  = 0.03f;
+    float  followTurnSpeed = 0.3f;
     if ( KeyPressed(SDLK_LSHIFT) ) {
         followCamSpeed *= 0.3f;
         followTurnSpeed *= 0.3f;
@@ -121,27 +121,26 @@ void Player::UpdatePlayerModel() {
     if ( turnRight == ButtonState::PRESSED ) {
         m_RotationAngle -= followTurnSpeed * (float)dt;
     }
-   
+
     // TODO: If dealing with m_Orientation quaternion, this test can be omitted.
-    if (m_RotationAngle >= 360.0f) {
+    if ( m_RotationAngle >= 360.0f ) {
         m_RotationAngle = 0.0f;
-    }
-    else if (m_RotationAngle < 0.0f) {
+    } else if ( m_RotationAngle < 0.0f ) {
         m_RotationAngle = 360.0f;
     }
 
-    glm::quat rot = glm::angleAxis(glm::radians(m_RotationAngle), glm::vec3(0.0f, 0.0f, 1.0f));
+    glm::quat rot       = glm::angleAxis(glm::radians(m_RotationAngle), glm::vec3(0.0f, 0.0f, 1.0f));
     m_Model.orientation = rot;
 
     m_Forward = glm::rotate(m_Model.orientation,
                             glm::vec3(0.0f, -1.0f, 0.0f)); // -1 because the model is facing -1 (Outside the screen)
-    m_Side = glm::cross(m_Forward, m_Up);
+    m_Side    = glm::cross(m_Forward, m_Up);
 
     // Change player's velocity and animation state based on input
-    m_Velocity = glm::vec3(0.0f);
-    float t = (float)dt * followCamSpeed;
+    m_Velocity                = glm::vec3(0.0f);
+    float     t               = (float)dt * followCamSpeed;
     AnimState playerAnimState = ANIM_STATE_IDLE;
-    
+
     if ( forward == ButtonState::PRESSED ) {
         m_Velocity += t * m_Forward;
         playerAnimState = ANIM_STATE_RUN;
@@ -159,7 +158,7 @@ void Player::UpdatePlayerModel() {
         playerAnimState = ANIM_STATE_RUN;
     }
 
-    if (playerAnimState == ANIM_STATE_RUN) {
+    if ( playerAnimState == ANIM_STATE_RUN ) {
         if ( speed == ButtonState::PRESSED ) {
             playerAnimState = ANIM_STATE_WALK;
         }
@@ -167,18 +166,18 @@ void Player::UpdatePlayerModel() {
 
     // Test the input handler here.
     ButtonState jumpState = CHECK_ACTION("jump");
-    if (jumpState == ButtonState::PRESSED) {
+    if ( jumpState == ButtonState::PRESSED ) {
         printf("I am jumping!\n");
     }
     ButtonState fireState = CHECK_ACTION("fire");
-    if (fireState == ButtonState::PRESSED) {
+    if ( fireState == ButtonState::PRESSED ) {
         printf("FIRE!\n");
     }
     ButtonState prevWeapon = CHECK_ACTION("switch_to_prev_weapon");
-    if (prevWeapon == ButtonState::WENT_DOWN) {
+    if ( prevWeapon == ButtonState::WENT_DOWN ) {
         printf("Switching to previous weapon!\n");
     }
-    
+
     SetAnimState(&m_Model, playerAnimState);
 
     // UpdateModel(&m_Model, (float)dt);
@@ -203,4 +202,3 @@ void Player::HandleInput() {
     }
     UpdatePlayerModel();
 }
-

--- a/Entity/Player/g_player.h
+++ b/Entity/Player/g_player.h
@@ -14,10 +14,9 @@
 #include "../../Message/message_dispatcher.h"
 #include "../../camera.h"
 #include "../../collision.h"
-#include "../../r_model.h"
 #include "../../input_receiver.h"
+#include "../../r_model.h"
 #include "../moving_entity.h"
-
 
 class Player : public MovingEntity, public IInputReceiver {
 
@@ -30,7 +29,7 @@ class Player : public MovingEntity, public IInputReceiver {
     void Update() override;
     bool HandleMessage(const Telegram& telegram) override;
     void HandleInput() override;
-    
+
     void UpdateCamera(Camera* camera);
     void UpdatePosition(glm::vec3 newPosition) override;
 
@@ -51,18 +50,18 @@ class Player : public MovingEntity, public IInputReceiver {
         }
         return false;
     }
-  
-private:
+
+  private:
     StateMachine<Player>* m_pStateMachine;
-    double m_AttackDelay = 100;
-    double m_LastAttack = 0;
+    double                m_AttackDelay = 100;
+    double                m_LastAttack  = 0;
 
     HKD_Model m_Model;
     // moving members
 
-private:
-    glm::vec3 m_Forward, m_Side;
-    AnimState m_AnimationState;
+  private:
+    glm::vec3         m_Forward, m_Side;
+    AnimState         m_AnimationState;
     EllipsoidCollider m_EllipsoidCollider;
 
     void LoadModel(const char* path, glm::vec3 initialPosition);
@@ -70,4 +69,3 @@ private:
 };
 
 #endif // PLAYER_H
-

--- a/Entity/Player/g_player_states.h
+++ b/Entity/Player/g_player_states.h
@@ -10,62 +10,62 @@
 
 class PlayerIdle : public State<Player> {
   private:
-	PlayerIdle() = default;
-	// copy ctor and assignment should be private
-	PlayerIdle(const PlayerIdle&);
-	PlayerIdle& operator=(const PlayerIdle&);
+    PlayerIdle() = default;
+    // copy ctor and assignment should be private
+    PlayerIdle(const PlayerIdle&);
+    PlayerIdle& operator=(const PlayerIdle&);
 
   public:
-	// this is a singleton
-	static PlayerIdle* Instance();
+    // this is a singleton
+    static PlayerIdle* Instance();
 
-	void Enter(Player* pPlayer) override;
+    void Enter(Player* pPlayer) override;
 
-	void Execute(Player* pPlayer) override;
+    void Execute(Player* pPlayer) override;
 
-	void Exit(Player* pPlayer) override;
+    void Exit(Player* pPlayer) override;
 
-	bool OnMessage(Player* agent, const Telegram& telegram) override;
+    bool OnMessage(Player* agent, const Telegram& telegram) override;
 };
 
 class PlayerRunning : public State<Player> {
   private:
-	PlayerRunning() = default;
-	// copy ctor and assignment should be private
-	PlayerRunning(const PlayerRunning&);
-	PlayerRunning& operator=(const PlayerRunning&);
+    PlayerRunning() = default;
+    // copy ctor and assignment should be private
+    PlayerRunning(const PlayerRunning&);
+    PlayerRunning& operator=(const PlayerRunning&);
 
   public:
-	// this is a singleton
-	static PlayerRunning* Instance();
+    // this is a singleton
+    static PlayerRunning* Instance();
 
-	void Enter(Player* pPlayer) override;
+    void Enter(Player* pPlayer) override;
 
-	void Execute(Player* pPlayer) override;
+    void Execute(Player* pPlayer) override;
 
-	void Exit(Player* pPlayer) override;
+    void Exit(Player* pPlayer) override;
 
-	bool OnMessage(Player* agent, const Telegram& telegram) override;
+    bool OnMessage(Player* agent, const Telegram& telegram) override;
 };
 
 class PlayerAttacking : public State<Player> {
   private:
-	PlayerAttacking() = default;
-	// copy ctor and assignment should be private
-	PlayerAttacking(const PlayerAttacking&);
-	PlayerAttacking& operator=(const PlayerAttacking&);
+    PlayerAttacking() = default;
+    // copy ctor and assignment should be private
+    PlayerAttacking(const PlayerAttacking&);
+    PlayerAttacking& operator=(const PlayerAttacking&);
 
   public:
-	// this is a singleton
-	static PlayerAttacking* Instance();
+    // this is a singleton
+    static PlayerAttacking* Instance();
 
-	void Enter(Player* pPlayer) override;
+    void Enter(Player* pPlayer) override;
 
-	void Execute(Player* pPlayer) override;
+    void Execute(Player* pPlayer) override;
 
-	void Exit(Player* pPlayer) override;
+    void Exit(Player* pPlayer) override;
 
-	bool OnMessage(Player* agent, const Telegram& telegram) override;
+    bool OnMessage(Player* agent, const Telegram& telegram) override;
 };
 
 #endif // PLAYERSTATES_H

--- a/Entity/base_game_entity.cpp
+++ b/Entity/base_game_entity.cpp
@@ -10,6 +10,5 @@
 // Called by entity manager who is responsible to assign IDs.
 //-----------------------------------------------------------------------------
 void BaseGameEntity::SetID(int value) {
-	m_ID = value;
+    m_ID = value;
 }
-

--- a/Entity/base_game_entity.h
+++ b/Entity/base_game_entity.h
@@ -11,9 +11,8 @@
 
 #include "../Message/telegram.h"
 #include "../collision.h"
-#include "../utils/utils.h"
 #include "../map_parser.h"
-
+#include "../utils/utils.h"
 
 // NOTE: (Michael): This is essentially what a discriminated union would give us in C.
 // TODO: (Michael): Game devs must be able to define their own ET_*. That would not go here
@@ -29,7 +28,7 @@ enum EntityType {
 
 class BaseGameEntity {
   private:
-    int m_ID{}; // Set by entity manager.
+    int        m_ID{}; // Set by entity manager.
     EntityType m_Type;
 
   public:
@@ -37,8 +36,7 @@ class BaseGameEntity {
         m_Type = type;
     }
 
-    template<typename T>
-    bool GetProperty(const std::vector<Property>& properties, std::string propName, T* value) {
+    template <typename T> bool GetProperty(const std::vector<Property>& properties, std::string propName, T* value) {
         for ( const Property& property : properties ) {
             if ( property.key == propName ) {
                 *value = ParseProperty<T>(property.value);
@@ -49,38 +47,32 @@ class BaseGameEntity {
         return false;
     }
 
-    template<typename T>
-    T ParseProperty(const std::string& sValue);
+    template <typename T> T ParseProperty(const std::string& sValue);
 
-    template<>
-    glm::vec3 ParseProperty<glm::vec3>(const std::string& sValue) {
+    template <> glm::vec3 ParseProperty<glm::vec3>(const std::string& sValue) {
         std::vector<float> origin = ParseValues<float>(sValue);
-        return glm::vec3( origin[0], origin[1], origin[2] );
+        return glm::vec3(origin[ 0 ], origin[ 1 ], origin[ 2 ]);
     }
 
-    template<>
-    std::string ParseProperty<std::string>(const std::string& sValue) {
+    template <> std::string ParseProperty<std::string>(const std::string& sValue) {
         return sValue;
     }
 
-    template<>
-    float ParseProperty<float>(const std::string& sValue) {
+    template <> float ParseProperty<float>(const std::string& sValue) {
         std::vector<float> floats = ParseValues<float>(sValue);
         return floats[ 0 ];
     }
-    
-    template<>
-    double ParseProperty<double>(const std::string& sValue) {
+
+    template <> double ParseProperty<double>(const std::string& sValue) {
         std::vector<double> floats = ParseValues<double>(sValue);
         return floats[ 0 ];
     }
-    
-    template<>
-    int ParseProperty<int>(const std::string& sValue) {
+
+    template <> int ParseProperty<int>(const std::string& sValue) {
         std::vector<int> ints = ParseValues<int>(sValue);
         return ints[ 0 ];
     }
-    
+
     virtual ~BaseGameEntity() = default;
 
     // all entities must implement an update function
@@ -97,7 +89,7 @@ class BaseGameEntity {
     }
 
     void SetID(int value);
-    
+
     [[nodiscard]] int ID() const {
         return m_ID;
     }
@@ -111,12 +103,11 @@ class BaseGameEntity {
     virtual EllipsoidCollider GetEllipsoidCollider() const {
         return {};
     };
-    
-    glm::vec3   m_Position = glm::vec3(0.0f);
-    glm::vec3   m_Velocity = glm::vec3(0.0f); // TODO: Actually make use of it and remove from subclasses!
-    float       m_RotationAngle = 0.0f; // TODO: Should be a quaternion called m_Orientation.
-    std::string m_Target = "";
+
+    glm::vec3   m_Position      = glm::vec3(0.0f);
+    glm::vec3   m_Velocity      = glm::vec3(0.0f); // TODO: Actually make use of it and remove from subclasses!
+    float       m_RotationAngle = 0.0f;            // TODO: Should be a quaternion called m_Orientation.
+    std::string m_Target        = "";
 };
 
 #endif // BASEGAMEENTITY_H
-

--- a/Entity/entity_manager.cpp
+++ b/Entity/entity_manager.cpp
@@ -64,9 +64,8 @@ void EntityManager::UpdateEntities() {
 std::vector<BaseGameEntity*> EntityManager::Entities() {
     std::vector<BaseGameEntity*> entities{};
     for ( auto [ id, entity ] : m_EntityMap ) {
-        entities.push_back( entity );
+        entities.push_back(entity);
     }
 
     return entities;
 }
-

--- a/Entity/entity_manager.h
+++ b/Entity/entity_manager.h
@@ -10,12 +10,12 @@
 #include <map>
 
 class EntityManager {
-private:
+  private:
     typedef std::map<int, BaseGameEntity*> EntityMap;
 
-public:
+  public:
     // copy ctor and assignment should be private
-    EntityManager(const EntityManager&) = delete;
+    EntityManager(const EntityManager&)            = delete;
     EntityManager& operator=(const EntityManager&) = delete;
     ~EntityManager();
 
@@ -26,7 +26,7 @@ public:
 
     // returns a pointer to the entity with the ID given as a parameter
     [[nodiscard]] BaseGameEntity* GetEntityFromID(int id) const;
-    [[nodiscard]] Enemy* GetFirstEnemy() const;
+    [[nodiscard]] Enemy*          GetFirstEnemy() const;
 
     // this method removes the entity from the list
     void RemoveEntity(const BaseGameEntity* pEntity);
@@ -35,14 +35,11 @@ public:
 
     // FIX: Slow!
     std::vector<BaseGameEntity*> Entities();
-  
 
-private:
+  private:
     EntityMap m_EntityMap;
     EntityManager() = default;
     int m_ID        = 0;
-
 };
 
 #endif // ENTITYMANAGER_H
-

--- a/Entity/moving_entity.cpp
+++ b/Entity/moving_entity.cpp
@@ -1,2 +1,1 @@
 #include "moving_entity.h"
-

--- a/Entity/moving_entity.h
+++ b/Entity/moving_entity.h
@@ -42,7 +42,7 @@ class MovingEntity : public BaseGameEntity {
     // all entities can communicate using messages. They are sent
     // using the MessageDispatcher singleton class
     virtual bool HandleMessage(const Telegram& telegram) = 0;
-    
+
     //a normalized vector pointing in the direction the entity is heading.
     glm::vec3 m_Forward;
 
@@ -64,4 +64,3 @@ class MovingEntity : public BaseGameEntity {
 };
 
 #endif // MOVINGENTITY_H
-

--- a/Entity/steering_behaviour.cpp
+++ b/Entity/steering_behaviour.cpp
@@ -26,8 +26,7 @@ SteeringBehaviour::SteeringBehaviour(MovingEntity* pEntity)
       m_pPath(nullptr),
       m_WanderTarget(0.0)
 
-{
-}
+{}
 
 glm::vec3 SteeringBehaviour::CalculateWeightedSum() {
     if ( On(seek) && m_pTargetAgent ) {
@@ -45,14 +44,14 @@ glm::vec3 SteeringBehaviour::CalculateWeightedSum() {
 
     if ( On(follow_waypoints) ) {
         if ( m_pPath != nullptr ) {
-        m_SteeringForce += FollowWaypoints(m_pPath) * m_WeightFollowWaypoints;
+            m_SteeringForce += FollowWaypoints(m_pPath) * m_WeightFollowWaypoints;
         } else {
             printf("SteeringBehaviour::FollowWaypoints: m_pPath is nullptr! Ignore.\n");
         }
     }
     if ( On(follow_path) ) {
         if ( m_pPath != nullptr ) {
-        m_SteeringForce += FollowPath(m_pPath) * m_WeightFollowPath;
+            m_SteeringForce += FollowPath(m_pPath) * m_WeightFollowPath;
         } else {
             printf("SteeringBehaviour::FollowPath: m_pPath is nullptr! Ignore.\n");
         }
@@ -155,22 +154,22 @@ glm::vec3 SteeringBehaviour::FollowPath(PatrolPath* path) {
     glm::vec3 segmentStart = path->GetCurrentWaypoint().position;
     glm::vec3 segmentEnd   = path->GetNextWaypoint().position;
 
-        // project the future position back onto the line to find a potential target
+    // project the future position back onto the line to find a potential target
     glm::vec3 normalPoint = math::GetProjectedPoint(futurePosition, segmentStart, segmentEnd);
     // check if the projected point is actually on the line segment, otherwise use the segment end for now.
     if ( !math::InSegmentRange(normalPoint, segmentStart, segmentEnd) ) {
-            normalPoint = segmentEnd;
-        }
-        // calculate the distance of the future position to the projected point to find the closest segment of the path
-        float distanceFromPath = glm::distance(futurePosition, normalPoint);
-            if ( path->GetRadius() <= distanceFromPath ) {
+        normalPoint = segmentEnd;
+    }
+    // calculate the distance of the future position to the projected point to find the closest segment of the path
+    float distanceFromPath = glm::distance(futurePosition, normalPoint);
+    if ( path->GetRadius() <= distanceFromPath ) {
         // the target is the normal point on the path plus a little offset in the direction of the path
-                target = normalPoint + glm::normalize(normalPoint - segmentStart) * 12.5f;
-            } else {
-                // NOTE: i don't know why this needs to be done ???
-                // if we are inside the radius of the path, we are on the path and need to target the next point
+        target = normalPoint + glm::normalize(normalPoint - segmentStart) * 12.5f;
+    } else {
+        // NOTE: i don't know why this needs to be done ???
+        // if we are inside the radius of the path, we are on the path and need to target the next point
         // just keeping the current velocity would probably be better
-                target = segmentEnd;
+        target = segmentEnd;
     }
 
     glm::vec3 force = Seek(target);

--- a/FSM/istate.h
+++ b/FSM/istate.h
@@ -8,20 +8,20 @@
 
 template <class entity_type> class State {
   public:
-	virtual ~State() = default;
+    virtual ~State() = default;
 
-	// this will execute when the state is entered
-	virtual void Enter(entity_type*) = 0;
+    // this will execute when the state is entered
+    virtual void Enter(entity_type*) = 0;
 
-	// this is the states normal update function
-	virtual void Execute(entity_type*) = 0;
+    // this is the states normal update function
+    virtual void Execute(entity_type*) = 0;
 
-	// this will execute when the state is exited.
-	virtual void Exit(entity_type*) = 0;
+    // this will execute when the state is exited.
+    virtual void Exit(entity_type*) = 0;
 
-	// this executes if the agent receives a message from the
-	// message dispatcher
-	virtual bool OnMessage(entity_type*, const Telegram&) = 0;
+    // this executes if the agent receives a message from the
+    // message dispatcher
+    virtual bool OnMessage(entity_type*, const Telegram&) = 0;
 };
 
 #endif // STATE_H

--- a/FSM/state_machine.h
+++ b/FSM/state_machine.h
@@ -11,100 +11,103 @@
 
 template <class entity_type> class StateMachine {
   private:
-	entity_type* m_pOwner;
-	State<entity_type>* m_pCurrentState;
-	State<entity_type>* m_pPreviousState;
-	State<entity_type>* m_pGlobalState;
+    entity_type*        m_pOwner;
+    State<entity_type>* m_pCurrentState;
+    State<entity_type>* m_pPreviousState;
+    State<entity_type>* m_pGlobalState;
 
   public:
-	explicit StateMachine(entity_type* owner)
-		: m_pOwner(owner), m_pCurrentState(nullptr), m_pPreviousState(nullptr), m_pGlobalState(nullptr){};
+    explicit StateMachine(entity_type* owner)
+        : m_pOwner(owner),
+          m_pCurrentState(nullptr),
+          m_pPreviousState(nullptr),
+          m_pGlobalState(nullptr) {};
 
-	virtual ~StateMachine() = default;
+    virtual ~StateMachine() = default;
 
-	// use these methods to initialize the FSM
-	void SetCurrentState(State<entity_type>* state) {
-		m_pCurrentState = state;
-	}
-	void SetGlobalState(State<entity_type>* state) {
-		m_pGlobalState = state;
-	}
-	void SetPreviousState(State<entity_type>* state) {
-		m_pPreviousState = state;
-	}
+    // use these methods to initialize the FSM
+    void SetCurrentState(State<entity_type>* state) {
+        m_pCurrentState = state;
+    }
+    void SetGlobalState(State<entity_type>* state) {
+        m_pGlobalState = state;
+    }
+    void SetPreviousState(State<entity_type>* state) {
+        m_pPreviousState = state;
+    }
 
-	// call this to update the FSM
-	void Update() const {
+    // call this to update the FSM
+    void Update() const {
 
-		// if a global state exists, call its execute method, else do nothing
-		if (m_pGlobalState) {
-			m_pGlobalState->Execute(m_pOwner);
-		}
+        // if a global state exists, call its execute method, else do nothing
+        if ( m_pGlobalState ) {
+            m_pGlobalState->Execute(m_pOwner);
+        }
 
-		// same for the current state
-		if (m_pCurrentState) {
-			m_pCurrentState->Execute(m_pOwner);
-		}
-	}
+        // same for the current state
+        if ( m_pCurrentState ) {
+            m_pCurrentState->Execute(m_pOwner);
+        }
+    }
 
-	// change to a new state
-	void ChangeState(State<entity_type>* pNewState) {
-		if (m_pCurrentState == pNewState) {
-			return;
-		}
-		assert(pNewState && "<StateMachine::ChangeState>:trying to assign null state to current");
+    // change to a new state
+    void ChangeState(State<entity_type>* pNewState) {
+        if ( m_pCurrentState == pNewState ) {
+            return;
+        }
+        assert(pNewState && "<StateMachine::ChangeState>:trying to assign null state to current");
 
-		// keep a record of the previous state
-		m_pPreviousState = m_pCurrentState;
+        // keep a record of the previous state
+        m_pPreviousState = m_pCurrentState;
 
-		// call the exit method of the existing state
-		m_pCurrentState->Exit(m_pOwner);
-		// change state to the new state
-		m_pCurrentState = pNewState;
+        // call the exit method of the existing state
+        m_pCurrentState->Exit(m_pOwner);
+        // change state to the new state
+        m_pCurrentState = pNewState;
 
-		// call the entry method of the new state
-		m_pCurrentState->Enter(m_pOwner);
-	}
+        // call the entry method of the new state
+        m_pCurrentState->Enter(m_pOwner);
+    }
 
-	// change state back to the previous state
-	void RevertToPreviousState() {
-		ChangeState(m_pPreviousState);
-	}
+    // change state back to the previous state
+    void RevertToPreviousState() {
+        ChangeState(m_pPreviousState);
+    }
 
-	// returns true if the current state's type is equal to the type of the
-	// class passed as a parameter.
-	bool IsInState(const State<entity_type>& state) const {
-		if (typeid(*m_pCurrentState) == typeid(state)) {
-			return true;
-		}
-		return false;
-	}
+    // returns true if the current state's type is equal to the type of the
+    // class passed as a parameter.
+    bool IsInState(const State<entity_type>& state) const {
+        if ( typeid(*m_pCurrentState) == typeid(state) ) {
+            return true;
+        }
+        return false;
+    }
 
-	State<entity_type>* CurrentState() const {
-		return m_pCurrentState;
-	}
-	State<entity_type>* GlobalState() const {
-		return m_pGlobalState;
-	}
-	State<entity_type>* PreviousState() const {
-		return m_pPreviousState;
-	}
+    State<entity_type>* CurrentState() const {
+        return m_pCurrentState;
+    }
+    State<entity_type>* GlobalState() const {
+        return m_pGlobalState;
+    }
+    State<entity_type>* PreviousState() const {
+        return m_pPreviousState;
+    }
 
-	bool HandleMessage(const Telegram& message) const {
-		// first see if the current state is valid and that it can handle
-		// the message
-		if (m_pCurrentState && m_pCurrentState->OnMessage(m_pOwner, message)) {
-			return true;
-		}
+    bool HandleMessage(const Telegram& message) const {
+        // first see if the current state is valid and that it can handle
+        // the message
+        if ( m_pCurrentState && m_pCurrentState->OnMessage(m_pOwner, message) ) {
+            return true;
+        }
 
-		// if not, and if a global state has been implemented, send
-		// the message to the global state
-		if (m_pGlobalState && m_pGlobalState->OnMessage(m_pOwner, message)) {
-			return true;
-		}
+        // if not, and if a global state has been implemented, send
+        // the message to the global state
+        if ( m_pGlobalState && m_pGlobalState->OnMessage(m_pOwner, message) ) {
+            return true;
+        }
 
-		return false;
-	}
+        return false;
+    }
 };
 
 #endif // STATEMACHINE_H

--- a/Intersections.cpp
+++ b/Intersections.cpp
@@ -10,8 +10,8 @@ bool Intersect(Body* bodyA, Body* bodyB, Contact& contact) {
     contact.bodyA = bodyA;
     contact.bodyB = bodyB;
 
-    glm::vec3 ab = bodyB->m_Position - bodyA->m_Position;
-    contact.normal = glm::normalize(ab);
+    glm::vec3 ab     = bodyB->m_Position - bodyA->m_Position;
+    contact.normal   = glm::normalize(ab);
     float distanceAB = glm::length(ab);
 
     ShapeSphere* shapeA = (ShapeSphere*)bodyA->m_Shape;
@@ -20,7 +20,7 @@ bool Intersect(Body* bodyA, Body* bodyB, Contact& contact) {
     contact.ptOnA_WorldSpace = bodyA->m_Position + shapeA->m_Radius * contact.normal;
     contact.ptOnB_WorldSpace = bodyB->m_Position - shapeB->m_Radius * contact.normal;
 
-    float radiusAB = shapeA->m_Radius + shapeB->m_Radius;
+    float radiusAB        = shapeA->m_Radius + shapeB->m_Radius;
     float distanceSquared = distanceAB * distanceAB;
 
     if ( distanceSquared < (radiusAB * radiusAB) ) {
@@ -29,6 +29,3 @@ bool Intersect(Body* bodyA, Body* bodyB, Contact& contact) {
 
     return false;
 }
-
-
-

--- a/Intersections.h
+++ b/Intersections.h
@@ -15,15 +15,14 @@ struct Contact {
     glm::vec3 ptOnA_LocalSpace;
     glm::vec3 ptOnB_LocalSpace;
 
-    glm::vec3 normal; // WorldSpace
+    glm::vec3 normal;             // WorldSpace
     float     separationDistance; // + when non-penetrating, - otherwise
     float     timeOfImpact;
 
-    Body*     bodyA;
-    Body*     bodyB;
+    Body* bodyA;
+    Body* bodyB;
 };
 
 bool Intersect(Body* bodyA, Body* bodyB, Contact& contact);
 
 #endif
-

--- a/Message/message_dispatcher.cpp
+++ b/Message/message_dispatcher.cpp
@@ -37,7 +37,7 @@ void MessageDispatcher::Discharge(BaseGameEntity* pReceiver, const Telegram& tel
 
 void MessageDispatcher::DispatchMessage(double delay, int sender, int receiver, int message, void* ExtraInfo) {
     // get pointers to the sender and receiver
-    BaseGameEntity* pSender = EntityManager::Instance()->GetEntityFromID(sender);
+    BaseGameEntity* pSender   = EntityManager::Instance()->GetEntityFromID(sender);
     BaseGameEntity* pReceiver = EntityManager::Instance()->GetEntityFromID(receiver);
 
     // make sure the receiver is valid

--- a/Message/message_dispatcher.h
+++ b/Message/message_dispatcher.h
@@ -16,13 +16,13 @@
 
 // to make code easier to read
 constexpr double SEND_MSG_IMMEDIATELY = 0.0;
-constexpr int NO_ADDITIONAL_INFO = 0;
-constexpr int SENDER_ID_IRRELEVANT = -1;
+constexpr int    NO_ADDITIONAL_INFO   = 0;
+constexpr int    SENDER_ID_IRRELEVANT = -1;
 
 class MessageDispatcher {
   private:
     std::set<Telegram> m_DelayedMessages;
-    void Discharge(BaseGameEntity* pReciever, const Telegram& message);
+    void               Discharge(BaseGameEntity* pReciever, const Telegram& message);
     MessageDispatcher() = default;
 
     // copy ctor and assignment should be private
@@ -38,4 +38,3 @@ class MessageDispatcher {
 };
 
 #endif // MESSAGEDISPATCHER_H
-

--- a/Message/message_type.h
+++ b/Message/message_type.h
@@ -14,22 +14,21 @@ enum message_type {
 };
 
 inline std::string MessageToString(int message) {
-    switch (message) {
+    switch ( message ) {
     case 0: {
-            return "Attack";
-        } break;
+        return "Attack";
+    } break;
     case 1: {
-            return "Hello World"; 
-        } break;
+        return "Hello World";
+    } break;
     case 2: {
-            return "Collision";
-        } break;
+        return "Collision";
+    } break;
 
     default: {
-            return "Not recognized!";
-        }
+        return "Not recognized!";
+    }
     }
 }
 
 #endif // MESSAGETYPE_H
-

--- a/Message/telegram.h
+++ b/Message/telegram.h
@@ -27,13 +27,22 @@ struct Telegram {
     // any additional information that may accompany the message
     void* ExtraInfo;
 
-    Telegram() : DispatchTime(-1), Sender(-1), Receiver(-1), Message(-1), ExtraInfo(nullptr) {}
+    Telegram()
+        : DispatchTime(-1),
+          Sender(-1),
+          Receiver(-1),
+          Message(-1),
+          ExtraInfo(nullptr) {}
 
     Telegram(const double time, const int sender, const int receiver, const int msg, void* info = nullptr)
-        : DispatchTime(time), Sender(sender), Receiver(receiver), Message(msg), ExtraInfo(info) {}
+        : DispatchTime(time),
+          Sender(sender),
+          Receiver(receiver),
+          Message(msg),
+          ExtraInfo(info) {}
 
     [[nodiscard]] char c_str() const {
-        char buffer[100];
+        char buffer[ 100 ];
         sprintf(buffer,
                 "telegram = time: %f, Sender: %i, Receiver %i, Message: %i",
                 DispatchTime,
@@ -52,13 +61,12 @@ struct Telegram {
 const double SmallestDelayInMS = 250;
 
 inline bool operator==(const Telegram& t1, const Telegram& t2) {
-    return (fabs(t1.DispatchTime - t2.DispatchTime) < SmallestDelayInMS) 
-            && (t1.Sender == t2.Sender)
-            && (t1.Receiver == t2.Receiver) && (t1.Message == t2.Message);
+    return (fabs(t1.DispatchTime - t2.DispatchTime) < SmallestDelayInMS) && (t1.Sender == t2.Sender)
+           && (t1.Receiver == t2.Receiver) && (t1.Message == t2.Message);
 }
 
 inline bool operator<(const Telegram& t1, const Telegram& t2) {
-    if (t1 == t2) {
+    if ( t1 == t2 ) {
         return false;
     }
 

--- a/Path/path.cpp
+++ b/Path/path.cpp
@@ -1,11 +1,11 @@
 #include <assert.h>
 
-#include <vector>
 #include <unordered_map>
+#include <vector>
 
-#include "./path.h"
 #include "../dependencies/glm/glm.hpp"
 #include "../r_common.h"
+#include "./path.h"
 
 void PatrolPath::AddPoint(Waypoint point) {
     point.pPatrolPath = this;
@@ -15,9 +15,9 @@ void PatrolPath::AddPoint(Waypoint point) {
     // TODO: m_CurrentWaypointName probably should be whatever is
     // specified for the entity targeting this path waypoint?
     if ( m_CurrentWaypointName.empty() ) {
-        m_Name = point.targetname;
+        m_Name                = point.targetname;
         m_CurrentWaypointName = point.targetname;
-        m_NextWaypointName = point.target;
+        m_NextWaypointName    = point.target;
     }
 }
 

--- a/Path/path.h
+++ b/Path/path.h
@@ -1,10 +1,10 @@
 #ifndef PATROL_PATH_H
 #define PATROL_PATH_H
 
-#include <string>
-#include <vector>
-#include <unordered_map>
 #include <assert.h>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 #include "../dependencies/glm/glm.hpp"
 #include "../r_common.h"
@@ -24,7 +24,7 @@ enum Direction {
 };
 
 class PatrolPath {
-public:
+  public:
     PatrolPath()
         : m_Points(),
           m_Radius(5.0),
@@ -48,7 +48,7 @@ public:
             Waypoint point = other->m_Points[ i ];
             // Makes sure that the point's path pointer points to this.
             // Also sets the m_CurrentWaypointName on first call.
-            AddPoint(point); 
+            AddPoint(point);
         }
         m_Name                 = other->m_Name;
         m_Radius               = other->m_Radius;
@@ -72,8 +72,8 @@ public:
     void                  SetCurrentWaypoint(std::string targetname);
     void                  SetNextWaypoint(std::string targetname);
     std::vector<Vertex>   GetPointsAsVertices();
-  
-public:
+
+  public:
     Direction   m_direction;
     float       m_OffsetToEntity = 0.0;
     float       m_Radius;
@@ -81,8 +81,8 @@ public:
     bool        IsClosed() {
         return m_Points.size() > 1 && m_Points[ 0 ].targetname == m_Points[ m_Points.size() - 1 ].target;
     };
-  
-private:
+
+  private:
     std::vector<Waypoint>                     m_Points;
     std::unordered_map<std::string, Waypoint> m_TargetnameToWaypoint;
     std::string                               m_CurrentWaypointName;

--- a/Shape.h
+++ b/Shape.h
@@ -8,19 +8,17 @@
 #include <glm/glm.hpp>
 
 class Shape {
-public:
+  public:
     enum ShapeType {
         SHAPE_SPHERE
     };
 
     virtual ShapeType GetType() const = 0;
-    virtual glm::vec3 GetCenterOfMass() const { return m_CenterOfMass; };
+    virtual glm::vec3 GetCenterOfMass() const {
+        return m_CenterOfMass;
+    };
 
     glm::vec3 m_CenterOfMass;
 };
-
-
-
-
 
 #endif //SHAPE_H

--- a/ShapeSphere.h
+++ b/ShapeSphere.h
@@ -10,15 +10,16 @@
 #include <glm/glm.hpp>
 
 class ShapeSphere : public Shape {
-public:
-    ShapeSphere(float radius) : m_Radius (radius) {
+  public:
+    ShapeSphere(float radius)
+        : m_Radius(radius) {
         m_CenterOfMass = glm::vec3(0.0f);
     };
-    ShapeType GetType() const override { return SHAPE_SPHERE; };
+    ShapeType GetType() const override {
+        return SHAPE_SPHERE;
+    };
 
     float m_Radius;
 };
-
-
 
 #endif //SHAPESPHERE_H

--- a/TestClass.cpp
+++ b/TestClass.cpp
@@ -5,5 +5,7 @@
 #include "TestClass.h"
 
 TestClass::TestClass() {
-    { printf("################# HI FROM TESTCLASS\n"); }
+    {
+        printf("################# HI FROM TESTCLASS\n");
+    }
 }

--- a/TestClass.h
+++ b/TestClass.h
@@ -8,10 +8,8 @@
 #include <stdio.h>
 
 class TestClass {
-public:
+  public:
     TestClass();
 };
-
-
 
 #endif //TESTCLASS_H

--- a/camera.cpp
+++ b/camera.cpp
@@ -1,55 +1,48 @@
 #include "camera.h"
 
-Camera::Camera(glm::vec3 pos)
-{
-	m_Pos = pos;
-	m_Forward = glm::vec3(0.0f, 1.0f, 0.0f);
-	m_Side = glm::vec3(1.0f, 0.0f, 0.0f);
-	m_Up = glm::vec3(0.0f, 0.0f, 1.0f);
-	m_Orientation = glm::angleAxis(glm::radians(0.0f), m_Up);
+Camera::Camera(glm::vec3 pos) {
+    m_Pos         = pos;
+    m_Forward     = glm::vec3(0.0f, 1.0f, 0.0f);
+    m_Side        = glm::vec3(1.0f, 0.0f, 0.0f);
+    m_Up          = glm::vec3(0.0f, 0.0f, 1.0f);
+    m_Orientation = glm::angleAxis(glm::radians(0.0f), m_Up);
 }
 
-void Camera::Pan(glm::vec3 direction)
-{
-	m_Pos += direction;
+void Camera::Pan(glm::vec3 direction) {
+    m_Pos += direction;
 }
 
-void Camera::Rotate(glm::quat quat)
-{
-	m_Orientation *= quat;
-	m_Up = glm::rotate(m_Orientation, m_Up);
-	m_Forward = glm::rotate(m_Orientation, m_Forward);
-	m_Side = glm::rotate(m_Orientation, m_Side);
+void Camera::Rotate(glm::quat quat) {
+    m_Orientation *= quat;
+    m_Up      = glm::rotate(m_Orientation, m_Up);
+    m_Forward = glm::rotate(m_Orientation, m_Forward);
+    m_Side    = glm::rotate(m_Orientation, m_Side);
 }
 
-void Camera::RotateAroundUp(float angle)
-{
-	glm::quat orientation = glm::angleAxis(glm::radians(angle), glm::vec3(0.0f, 0.0f, 1.0f));
-	m_Up = glm::rotate(orientation, m_Up);
-	m_Forward = glm::rotate(orientation, m_Forward);
-	m_Side = glm::rotate(orientation, m_Side);
-	m_Orientation *= orientation;
+void Camera::RotateAroundUp(float angle) {
+    glm::quat orientation = glm::angleAxis(glm::radians(angle), glm::vec3(0.0f, 0.0f, 1.0f));
+    m_Up                  = glm::rotate(orientation, m_Up);
+    m_Forward             = glm::rotate(orientation, m_Forward);
+    m_Side                = glm::rotate(orientation, m_Side);
+    m_Orientation *= orientation;
 }
 
-void Camera::RotateAroundSide(float angle)
-{
-	glm::quat orientation = glm::angleAxis(glm::radians(angle), m_Side);
-	m_Up = glm::rotate(orientation, m_Up);
-	m_Forward = glm::rotate(orientation, m_Forward);
-	m_Orientation *= orientation;
+void Camera::RotateAroundSide(float angle) {
+    glm::quat orientation = glm::angleAxis(glm::radians(angle), m_Side);
+    m_Up                  = glm::rotate(orientation, m_Up);
+    m_Forward             = glm::rotate(orientation, m_Forward);
+    m_Orientation *= orientation;
 }
 
 void Camera::SetOrientationFromAngle(float angle, glm::vec3 axis) {
-	glm::quat orientation = glm::angleAxis( glm::radians(angle), axis );
-	m_Up = glm::rotate( orientation, glm::vec3(0.0f, 0.0f, 1.0f) );
-	m_Forward = glm::rotate( orientation, glm::vec3(0.0f, 1.0f, 0.0f) );
-	m_Side = glm::rotate( orientation, glm::vec3(1.0f, 0.0f, 0.0f) );
-	m_Orientation = orientation;
+    glm::quat orientation = glm::angleAxis(glm::radians(angle), axis);
+    m_Up                  = glm::rotate(orientation, glm::vec3(0.0f, 0.0f, 1.0f));
+    m_Forward             = glm::rotate(orientation, glm::vec3(0.0f, 1.0f, 0.0f));
+    m_Side                = glm::rotate(orientation, glm::vec3(1.0f, 0.0f, 0.0f));
+    m_Orientation         = orientation;
 }
 
-glm::mat4 Camera::ViewMatrix(void)
-{
-	glm::vec3 center = m_Pos + m_Forward;
-	return glm::lookAt(m_Pos, center, m_Up);
+glm::mat4 Camera::ViewMatrix(void) {
+    glm::vec3 center = m_Pos + m_Forward;
+    return glm::lookAt(m_Pos, center, m_Up);
 }
-

--- a/camera.h
+++ b/camera.h
@@ -2,29 +2,27 @@
 #define _CAMERA_H_
 
 #define GLM_FORCE_RADIANS
-#include "dependencies/glm/glm.hpp"
 #include "dependencies/glm/ext.hpp"
+#include "dependencies/glm/glm.hpp"
 #include "dependencies/glm/gtx/quaternion.hpp"
 
 class Camera {
-public:
-	
-	Camera(glm::vec3 pos = glm::vec3(0.0f));
+  public:
+    Camera(glm::vec3 pos = glm::vec3(0.0f));
 
-	void Pan(glm::vec3 direction);
-	void Rotate(glm::quat quat);
-	void RotateAroundUp(float angle);
-	void RotateAroundSide(float angle);
-	void SetOrientationFromAngle(float angle, glm::vec3 axis);
+    void Pan(glm::vec3 direction);
+    void Rotate(glm::quat quat);
+    void RotateAroundUp(float angle);
+    void RotateAroundSide(float angle);
+    void SetOrientationFromAngle(float angle, glm::vec3 axis);
 
-	glm::mat4 ViewMatrix(void);
+    glm::mat4 ViewMatrix(void);
 
-	glm::vec3 m_Pos;
-	glm::vec3 m_Forward;
-	glm::vec3 m_Side;
-	glm::vec3 m_Up;
-	glm::quat m_Orientation;
+    glm::vec3 m_Pos;
+    glm::vec3 m_Forward;
+    glm::vec3 m_Side;
+    glm::vec3 m_Up;
+    glm::quat m_Orientation;
 };
 
 #endif
-

--- a/collision.cpp
+++ b/collision.cpp
@@ -2,70 +2,65 @@
 // Created by me on 9/2/24.
 //
 
-
-#include <vector>
 #include <stdio.h>
+#include <vector>
 
 #include <glm/gtx/norm.hpp>
 
-#include "r_common.h"
 #include "collision.h"
+#include "r_common.h"
 
 // NOTE: This distance depends very much on the size of the level geometry!
 #define VERY_CLOSE_DIST 0.01f
 
-EllipsoidCollider CreateEllipsoidColliderFromAABB(glm::vec3 mins, glm::vec3 maxs)
-{
-    float width = glm::abs(maxs.x - mins.x);
-    float height = glm::abs(maxs.z - mins.z);
+EllipsoidCollider CreateEllipsoidColliderFromAABB(glm::vec3 mins, glm::vec3 maxs) {
+    float             width  = glm::abs(maxs.x - mins.x);
+    float             height = glm::abs(maxs.z - mins.z);
     EllipsoidCollider result{};
-    float radiusA = width / 2.0f;
-    float radiusB = height / 2.0f;
-    result.radiusA = radiusA;
-    result.radiusB = radiusB;
-    result.center = glm::vec3(0.0f);
-    glm::vec3 s = glm::vec3(1.0f / radiusA, 1.0f / radiusA, 1.0f / radiusB);
-    glm::mat3 invESpace = glm::scale(glm::mat4(1.0f), s);
-    result.toESpace = invESpace;
+    float             radiusA = width / 2.0f;
+    float             radiusB = height / 2.0f;
+    result.radiusA            = radiusA;
+    result.radiusB            = radiusB;
+    result.center             = glm::vec3(0.0f);
+    glm::vec3 s               = glm::vec3(1.0f / radiusA, 1.0f / radiusA, 1.0f / radiusB);
+    glm::mat3 invESpace       = glm::scale(glm::mat4(1.0f), s);
+    result.toESpace           = invESpace;
 
     return result;
 }
 
 // Assumes Triangle in CCW order.
-glm::vec3 ConstructNormalToTriLineSegment(glm::vec3 a, glm::vec3 b, glm::vec3 planeNormal)
-{
-    glm::vec3 AB = glm::normalize(b - a);
+glm::vec3 ConstructNormalToTriLineSegment(glm::vec3 a, glm::vec3 b, glm::vec3 planeNormal) {
+    glm::vec3 AB  = glm::normalize(b - a);
     glm::vec3 nAB = glm::normalize(glm::cross(planeNormal, AB));
 
     return nAB;
 }
 
-float SignedDistancePointToPlane(glm::vec3 pt, glm::vec3 ptOnPlane, glm::vec3 planeNormal)
-{
+float SignedDistancePointToPlane(glm::vec3 pt, glm::vec3 ptOnPlane, glm::vec3 planeNormal) {
     glm::vec3 pVec = pt - ptOnPlane;
-    float sD = glm::dot(pVec, planeNormal);
+    float     sD   = glm::dot(pVec, planeNormal);
 
     return sD;
 }
 
-bool IsPointInTriangle(glm::vec3 point, Tri tri, glm::vec3 triNormal)
-{
-    glm::vec3 nAB = ConstructNormalToTriLineSegment(tri.a.pos, tri.b.pos, triNormal);
-    float sdABplane = SignedDistancePointToPlane(point, tri.a.pos, nAB);
+bool IsPointInTriangle(glm::vec3 point, Tri tri, glm::vec3 triNormal) {
+    glm::vec3 nAB       = ConstructNormalToTriLineSegment(tri.a.pos, tri.b.pos, triNormal);
+    float     sdABplane = SignedDistancePointToPlane(point, tri.a.pos, nAB);
     // printf("sdABplane: %f\n", sdABplane);
-    if (sdABplane <= 0.0f) {
+    if ( sdABplane <= 0.0f ) {
         return false;
     }
 
-    glm::vec3 nBC = ConstructNormalToTriLineSegment(tri.b.pos, tri.c.pos, triNormal);
-    float sdBCplane = SignedDistancePointToPlane(point, tri.b.pos, nBC);
-    if (sdBCplane <= 0.0f) {
+    glm::vec3 nBC       = ConstructNormalToTriLineSegment(tri.b.pos, tri.c.pos, triNormal);
+    float     sdBCplane = SignedDistancePointToPlane(point, tri.b.pos, nBC);
+    if ( sdBCplane <= 0.0f ) {
         return false;
     }
 
-    glm::vec3 nCA = ConstructNormalToTriLineSegment(tri.c.pos, tri.a.pos, triNormal);
-    float sdCAplane = SignedDistancePointToPlane(point, tri.c.pos, nCA);
-    if (sdCAplane <= 0.0f) {
+    glm::vec3 nCA       = ConstructNormalToTriLineSegment(tri.c.pos, tri.a.pos, triNormal);
+    float     sdCAplane = SignedDistancePointToPlane(point, tri.c.pos, nCA);
+    if ( sdCAplane <= 0.0f ) {
         return false;
     }
 
@@ -74,43 +69,42 @@ bool IsPointInTriangle(glm::vec3 point, Tri tri, glm::vec3 triNormal)
 
 // If a > b then the two will be swapped.
 // Otherwise, nothing happens.
-void SortFloats(float* a, float* b)
-{
-    if (*a > *b) {
+void SortFloats(float* a, float* b) {
+    if ( *a > *b ) {
         float tmp = *a;
-        *a = *b;
-        *b = tmp;
+        *a        = *b;
+        *b        = tmp;
     }
 }
 
 void SortDoubles(double* a, double* b) {
-    if (*a > *b) {
+    if ( *a > *b ) {
         double tmp = *a;
-        *a = *b;
-        *b = tmp;
+        *a         = *b;
+        *b         = tmp;
     }
 }
 
-#define SortValues(a, b, t) do { \
-        t(&a, &b); \
-    } while(0); \
+#define SortValues(a, b, t)                                                                                            \
+    do {                                                                                                               \
+        t(&a, &b);                                                                                                     \
+    } while ( 0 );
 
-bool GetSmallestRoot(float a, float b, float c, float maxRoot, float* root)
-{
-    float D = b*b - 4.0f*a*c;
-    if (D < 0.0f) {
+bool GetSmallestRoot(float a, float b, float c, float maxRoot, float* root) {
+    float D = b * b - 4.0f * a * c;
+    if ( D < 0.0f ) {
         return false;
     }
 
     float sqrtD = glm::sqrt(D);
     float denom = 1.0f / (2.0f * a);
-    float r0 = (-b - sqrtD) * denom;
-    float r1 = (-b + sqrtD) * denom;
+    float r0    = (-b - sqrtD) * denom;
+    float r1    = (-b + sqrtD) * denom;
 
     // Make sure we have the lowest solution in r0.
     SortValues(r0, r1, SortFloats);
 
-    if (r0 > 0.0f && r0 < maxRoot) {
+    if ( r0 > 0.0f && r0 < maxRoot ) {
         *root = r0;
         return true;
     }
@@ -118,7 +112,7 @@ bool GetSmallestRoot(float a, float b, float c, float maxRoot, float* root)
     // r0 could be a negative solution. In plain math this is ok,
     // but we are only interested in values that are between
     // 0 and maxRoot (which is 1 at maximum).
-    if (r1 > 0.0f && r1 < maxRoot) {
+    if ( r1 > 0.0f && r1 < maxRoot ) {
         *root = r1;
         return true;
     }
@@ -130,13 +124,13 @@ bool IsPointOnLineSegment(glm::vec3 p, glm::vec3 a, glm::vec3 b) {
     // Check if the intersection point between sphere and plane we found
     // earlier lies on one of the 3 triangle's edges.
     // Firstly, check if the intersection point is on the line.
-    glm::vec3 edge = glm::normalize(b - a);
-    glm::vec3 pVec = glm::normalize(p - a);
-    float edgeDotPVec = glm::dot(edge, pVec);
+    glm::vec3 edge        = glm::normalize(b - a);
+    glm::vec3 pVec        = glm::normalize(p - a);
+    float     edgeDotPVec = glm::dot(edge, pVec);
     printf("edgeDotPVec = %f\n", edgeDotPVec);
     if ( edgeDotPVec >= HKD_EPSILON ) { // intersection point lies on line
         float lenE0 = glm::length(edge);
-        float lenP = glm::length(pVec);
+        float lenP  = glm::length(pVec);
         if ( lenP < lenE0 ) {
             return true;
         }
@@ -145,56 +139,57 @@ bool IsPointOnLineSegment(glm::vec3 p, glm::vec3 a, glm::vec3 b) {
     return false;
 }
 
-bool CheckSweptSphereVsLinesegment(
-        glm::vec3 p0, glm::vec3 p1, 
-        glm::vec3 sphereBase, glm::vec3 velocity, 
-        float maxT, float *out_newT,
-        glm::vec3* out_hitPoint) {
+bool CheckSweptSphereVsLinesegment(glm::vec3  p0,
+                                   glm::vec3  p1,
+                                   glm::vec3  sphereBase,
+                                   glm::vec3  velocity,
+                                   float      maxT,
+                                   float*     out_newT,
+                                   glm::vec3* out_hitPoint) {
     // Check sphere against tri's line-segments
-    
-    glm::vec3 e = p1 - p0;
-    float eSquaredLength = glm::length2(e);
-    float vSquaredLength = glm::length2(velocity);
-    glm::vec3 baseToVertex = p0 - sphereBase;
-    float eDotVel = glm::dot(e, velocity);
-    float eDotBaseToVertex = glm::dot(e, baseToVertex);
 
-    float a = eSquaredLength * (-vSquaredLength) + eDotVel*eDotVel;
-    float b = eSquaredLength * 2.0f*glm::dot(velocity, baseToVertex) - 2.0f*( eDotVel * eDotBaseToVertex );
-    float c = eSquaredLength * ( 1.0f - glm::length2(baseToVertex) ) + eDotBaseToVertex*eDotBaseToVertex;
+    glm::vec3 e                = p1 - p0;
+    float     eSquaredLength   = glm::length2(e);
+    float     vSquaredLength   = glm::length2(velocity);
+    glm::vec3 baseToVertex     = p0 - sphereBase;
+    float     eDotVel          = glm::dot(e, velocity);
+    float     eDotBaseToVertex = glm::dot(e, baseToVertex);
+
+    float a = eSquaredLength * (-vSquaredLength) + eDotVel * eDotVel;
+    float b = eSquaredLength * 2.0f * glm::dot(velocity, baseToVertex) - 2.0f * (eDotVel * eDotBaseToVertex);
+    float c = eSquaredLength * (1.0f - glm::length2(baseToVertex)) + eDotBaseToVertex * eDotBaseToVertex;
 
     float t;
     if ( GetSmallestRoot(a, b, c, maxT, &t) ) {
         // Now check if hitpoint is withing the line segment.
-        float f = (eDotVel*t - eDotBaseToVertex) / eSquaredLength;
-        if (f >= 0.0f && f <= 1.0f) {
-            *out_newT = t;
-            *out_hitPoint = p0 + f*e;
+        float f = (eDotVel * t - eDotBaseToVertex) / eSquaredLength;
+        if ( f >= 0.0f && f <= 1.0f ) {
+            *out_newT     = t;
+            *out_hitPoint = p0 + f * e;
 
             return true;
         }
     }
-    
+
     return false;
 }
 
-void CollideUnitSphereWithTri(CollisionInfo* ci, Tri tri)
-{
-    Plane p = CreatePlaneFromTri(tri);
-    glm::vec3 normal = p.normal;
+void CollideUnitSphereWithTri(CollisionInfo* ci, Tri tri) {
+    Plane     p         = CreatePlaneFromTri(tri);
+    glm::vec3 normal    = p.normal;
     glm::vec3 ptOnPlane = p.d * normal;
-    glm::vec3 basePos = ci->basePos;
-    glm::vec3 velocity = ci->velocity;
+    glm::vec3 basePos   = ci->basePos;
+    glm::vec3 velocity  = ci->velocity;
 
-    if ( glm::dot( glm::normalize(velocity), normal ) >= 0.0f ) return;
+    if ( glm::dot(glm::normalize(velocity), normal) >= 0.0f ) return;
     // Signed distance from plane to unit sphere's center
     float sD = glm::dot(normal, basePos - ptOnPlane);
 
     // Project velocity along the plane normal
     float velDotNormal = glm::dot(normal, velocity);
 
-    bool foundCollision = false;
-    bool embeddedInPlane = false;
+    bool  foundCollision  = false;
+    bool  embeddedInPlane = false;
     float t0, t1;
     if ( glm::abs(velDotNormal) == 0.0f ) { // Sphere travelling parallel to the plane or it is in the plane
 
@@ -202,12 +197,11 @@ void CollideUnitSphereWithTri(CollisionInfo* ci, Tri tri)
         if ( glm::abs(sD) >= 1.0f ) {
             return;
         }
-        
-        t0 = 0.0f;
-        t1 = 1.0f;
+
+        t0              = 0.0f;
+        t1              = 1.0f;
         embeddedInPlane = true;
-    }
-    else { // N Dot D not 0! There could be an intersection!
+    } else { // N Dot D not 0! There could be an intersection!
 
         // Calculate t0, that is the time when the unit sphere hits the
         // front face of the plane.
@@ -224,13 +218,13 @@ void CollideUnitSphereWithTri(CollisionInfo* ci, Tri tri)
         // the sphere is, t0 might not be the smallest value.
         // But we need the smallest because it is the maximum we can
         // travel the sphere along the velocity vector before a collision happens.
-        if (t0 > t1) {
+        if ( t0 > t1 ) {
             float tmp = t0;
-            t0 = t1;
-            t1 = tmp;
+            t0        = t1;
+            t1        = tmp;
         }
 
-        if (t0 > 1.0f || t1 < 0.0f) { // No collision
+        if ( t0 > 1.0f || t1 < 0.0f ) { // No collision
             return;
         }
 
@@ -242,18 +236,17 @@ void CollideUnitSphereWithTri(CollisionInfo* ci, Tri tri)
     // This is only possible when the intersection point is not embedded inside
     // the plane.
     glm::vec3 hitPoint;
-    float t = 1.0f;
-    if (!embeddedInPlane) {
+    float     t = 1.0f;
+    if ( !embeddedInPlane ) {
         // Check if the intersection is INSIDE the triangle.
-        glm::vec3 intersectionPoint = basePos + t0*velocity - normal;
+        glm::vec3 intersectionPoint = basePos + t0 * velocity - normal;
         if ( IsPointInTriangle(intersectionPoint, tri, normal) ) { // TODO: Rename function!
             foundCollision = true;
-            hitPoint = intersectionPoint;
+            hitPoint       = intersectionPoint;
             //printf("Point inside tri side planes.\n");
             t = t0;
             //printf("IsPointInTriangle: true\n");
-        }
-        else {
+        } else {
             //printf("Point outside tri side planes.\n");
         }
     }
@@ -266,138 +259,138 @@ void CollideUnitSphereWithTri(CollisionInfo* ci, Tri tri)
     // where C(t) is the current pos of the sphere on its velocity vector:
     // C(t) = basePos + t * velocity
     // p is one of the vertices of the tri.
-    if (!foundCollision) {
+    if ( !foundCollision ) {
         float a = glm::length2(velocity);
         float newT;
         // Check point A
-        float b = 2.0f * ( glm::dot(velocity, (basePos - tri.a.pos)) );
+        float b = 2.0f * (glm::dot(velocity, (basePos - tri.a.pos)));
         float c = glm::distance2(tri.a.pos, basePos) - 1.0f;
         // Find smallest solution, if available
-        if (GetSmallestRoot(a, b, c, t, &newT)) {
-            t = newT;
+        if ( GetSmallestRoot(a, b, c, t, &newT) ) {
+            t              = newT;
             foundCollision = true;
-            hitPoint = tri.a.pos;
+            hitPoint       = tri.a.pos;
         }
 
         // Check point B
-        b = 2.0f * ( glm::dot(velocity, (basePos - tri.b.pos)) );
+        b = 2.0f * (glm::dot(velocity, (basePos - tri.b.pos)));
         c = glm::distance2(tri.b.pos, basePos) - 1.0f;
         // Find smallest solution, if available
-        if (GetSmallestRoot(a, b, c, t, &newT)) {
-            t = newT;
+        if ( GetSmallestRoot(a, b, c, t, &newT) ) {
+            t              = newT;
             foundCollision = true;
-            hitPoint = tri.b.pos;
+            hitPoint       = tri.b.pos;
         }
 
         // Check point C
-        b = 2.0f * ( glm::dot(velocity, (basePos - tri.c.pos)) );
+        b = 2.0f * (glm::dot(velocity, (basePos - tri.c.pos)));
         c = glm::distance2(tri.c.pos, basePos) - 1.0f;
         // Find smallest solution, if available
-        if (GetSmallestRoot(a, b, c, t, &newT)) {
-            t = newT;
+        if ( GetSmallestRoot(a, b, c, t, &newT) ) {
+            t              = newT;
             foundCollision = true;
-            hitPoint = tri.c.pos;   
+            hitPoint       = tri.c.pos;
         }
 
         // Check sphere against tri's line-segments
 
         if ( CheckSweptSphereVsLinesegment(tri.a.pos, tri.b.pos, basePos, velocity, t, &newT, &hitPoint) ) {
             foundCollision = true;
-            t = newT;
+            t              = newT;
         }
 
         if ( CheckSweptSphereVsLinesegment(tri.b.pos, tri.c.pos, basePos, velocity, t, &newT, &hitPoint) ) {
             foundCollision = true;
-            t = newT;
+            t              = newT;
         }
 
         if ( CheckSweptSphereVsLinesegment(tri.c.pos, tri.a.pos, basePos, velocity, t, &newT, &hitPoint) ) {
             foundCollision = true;
-            t = newT;
+            t              = newT;
         }
     }
 
-    if (foundCollision) {
-        float distanceToHitpoint = t * glm::length( velocity ); // furthest the sphere can travel along its velocity vector until collision happens
+    if ( foundCollision ) {
+        float distanceToHitpoint
+            = t
+              * glm::length(
+                  velocity); // furthest the sphere can travel along its velocity vector until collision happens
         if ( !ci->didCollide || (ci->nearestDistance > distanceToHitpoint) ) {
-            ci->didCollide = true;
+            ci->didCollide      = true;
             ci->nearestDistance = distanceToHitpoint;
-            ci->hitPoint = hitPoint;
-            if (embeddedInPlane) {
+            ci->hitPoint        = hitPoint;
+            if ( embeddedInPlane ) {
                 //ci->nearestDistance = -VERY_CLOSE_DIST;
                 //ci->hitPoint -= VERY_CLOSE_DIST*p.normal;
             }
         }
     }
-
 }
 
-CollisionInfo CollideEllipsoidWithMapTris(EllipsoidCollider ec, 
-                                          glm::vec3 velocity, 
-                                          glm::vec3 gravity, 
-                                          MapTri* tris, int triCount,
-                                          std::vector< std::vector<MapTri>* > brushMapTris)
-{
+CollisionInfo CollideEllipsoidWithMapTris(EllipsoidCollider                 ec,
+                                          glm::vec3                         velocity,
+                                          glm::vec3                         gravity,
+                                          MapTri*                           tris,
+                                          int                               triCount,
+                                          std::vector<std::vector<MapTri>*> brushMapTris) {
     // Convert to ellipsoid space
     std::vector<Tri> esTris;
-    for (int i = 0; i < triCount; i++) {
-        Tri tri = tris[ i ].tri;
+    for ( int i = 0; i < triCount; i++ ) {
+        Tri tri   = tris[ i ].tri;
         Tri esTri = TriToEllipsoidSpace(tri, ec.toESpace);
         esTris.push_back(esTri);
     }
     // Also do this for the brush tris
-    for (int i = 0; i < brushMapTris.size(); i++) {
-        std::vector<MapTri>* pMapTris = brushMapTris[i];
-        for (int j = 0; j < pMapTris->size(); j++) {
-            Tri tri = pMapTris->at(j).tri;
+    for ( int i = 0; i < brushMapTris.size(); i++ ) {
+        std::vector<MapTri>* pMapTris = brushMapTris[ i ];
+        for ( int j = 0; j < pMapTris->size(); j++ ) {
+            Tri tri   = pMapTris->at(j).tri;
             Tri esTri = TriToEllipsoidSpace(tri, ec.toESpace);
             esTris.push_back(esTri);
         }
     }
-    
+
     glm::vec3 esVelocity = ec.toESpace * velocity;
-    glm::vec3 esBasePos = ec.toESpace * ec.center;
-    
+    glm::vec3 esBasePos  = ec.toESpace * ec.center;
+
     // From now on the Radius of the ellipsoid is 1.0 in X, Y, Z.
     // Thus, it is a unit sphere.
-    
+
     CollisionInfo ci;
-    ci.didCollide = false;
+    ci.didCollide      = false;
     ci.nearestDistance = 0.0f;
-    ci.velocity = esVelocity;
-    ci.hitPoint = glm::vec3( 0.0f );
-    ci.basePos = esBasePos;
+    ci.velocity        = esVelocity;
+    ci.hitPoint        = glm::vec3(0.0f);
+    ci.basePos         = esBasePos;
 
     glm::vec3 newPos = CollideEllipsoidWithTrisRec(&ci, esBasePos, esVelocity, esTris.data(), esTris.size(), 0, 5);
 
     glm::vec3 esGravity = ec.toESpace * gravity;
-    ci.velocity = esGravity;
-    ci.basePos = newPos;
-    ci.nearestDistance = 0.0f;
-    ci.didCollide = false;
-    newPos = CollideEllipsoidWithTrisRec(&ci, newPos, esGravity, esTris.data(), esTris.size(), 0, 5);
+    ci.velocity         = esGravity;
+    ci.basePos          = newPos;
+    ci.nearestDistance  = 0.0f;
+    ci.didCollide       = false;
+    newPos              = CollideEllipsoidWithTrisRec(&ci, newPos, esGravity, esTris.data(), esTris.size(), 0, 5);
 
-    ci.velocity = glm::inverse( ec.toESpace ) * ci.velocity;
-    ci.hitPoint = glm::inverse( ec.toESpace ) * ci.hitPoint;
-    ci.basePos = glm::inverse( ec.toESpace ) * newPos;
+    ci.velocity = glm::inverse(ec.toESpace) * ci.velocity;
+    ci.hitPoint = glm::inverse(ec.toESpace) * ci.hitPoint;
+    ci.basePos  = glm::inverse(ec.toESpace) * newPos;
 
     return ci;
 }
 
 // Assume all data in ci to be in ellipsoid space, that is, a unit-sphere. Same goes for esBasePos.
-glm::vec3 CollideEllipsoidWithTrisRec(CollisionInfo* ci, glm::vec3 esBasePos, glm::vec3 velocity, Tri* tris, int triCount, int depth, int maxDepth)
-{
-    if ( depth > maxDepth ) 
-        return esBasePos;
-
+glm::vec3 CollideEllipsoidWithTrisRec(
+    CollisionInfo* ci, glm::vec3 esBasePos, glm::vec3 velocity, Tri* tris, int triCount, int depth, int maxDepth) {
+    if ( depth > maxDepth ) return esBasePos;
 
     ci->didCollide = false;
-    ci->velocity = velocity;
-    ci->basePos = esBasePos;
+    ci->velocity   = velocity;
+    ci->basePos    = esBasePos;
 
-    for (int i = 0; i < triCount; i++) {
+    for ( int i = 0; i < triCount; i++ ) {
         Tri tri = tris[ i ];
-        CollideUnitSphereWithTri( ci, tri );
+        CollideUnitSphereWithTri(ci, tri);
     }
 
     if ( !ci->didCollide ) {
@@ -405,21 +398,21 @@ glm::vec3 CollideEllipsoidWithTrisRec(CollisionInfo* ci, glm::vec3 esBasePos, gl
     }
 
     glm::vec3 destinationPos = esBasePos + velocity;
-    glm::vec3 newBasePos = esBasePos;
+    glm::vec3 newBasePos     = esBasePos;
 
     if ( ci->nearestDistance >= VERY_CLOSE_DIST ) {
-        glm::vec3 v = velocity;
-        glm::vec3 vNorm = glm::normalize( v );
-        float length = glm::abs(ci->nearestDistance - VERY_CLOSE_DIST); // abs should not be neccessary
-        newBasePos = ci->basePos + length * vNorm; 
+        glm::vec3 v      = velocity;
+        glm::vec3 vNorm  = glm::normalize(v);
+        float     length = glm::abs(ci->nearestDistance - VERY_CLOSE_DIST); // abs should not be neccessary
+        newBasePos       = ci->basePos + length * vNorm;
         ci->hitPoint -= VERY_CLOSE_DIST * vNorm;
     }
 
     Plane slidingPlane{};
-    slidingPlane.p = ci->hitPoint;
-    slidingPlane.normal = glm::normalize( newBasePos - ci->hitPoint );
-    float distance = glm::dot( destinationPos - slidingPlane.p, slidingPlane.normal );
-    glm::vec3 newDestinationPos = destinationPos - distance*slidingPlane.normal;
+    slidingPlane.p              = ci->hitPoint;
+    slidingPlane.normal         = glm::normalize(newBasePos - ci->hitPoint);
+    float     distance          = glm::dot(destinationPos - slidingPlane.p, slidingPlane.normal);
+    glm::vec3 newDestinationPos = destinationPos - distance * slidingPlane.normal;
 
     glm::vec3 newVelocity = newDestinationPos - ci->hitPoint;
 
@@ -427,11 +420,11 @@ glm::vec3 CollideEllipsoidWithTrisRec(CollisionInfo* ci, glm::vec3 esBasePos, gl
         return newBasePos;
     }
 
-    return CollideEllipsoidWithTrisRec( ci, newBasePos, newVelocity, tris, triCount, depth + 1, maxDepth );
+    return CollideEllipsoidWithTrisRec(ci, newBasePos, newVelocity, tris, triCount, depth + 1, maxDepth);
 }
 
 Tri TriToEllipsoidSpace(Tri tri, glm::mat3 toESPace) {
-    Tri result = tri;
+    Tri result   = tri;
     result.a.pos = toESPace * tri.a.pos;
     result.b.pos = toESPace * tri.b.pos;
     result.c.pos = toESPace * tri.c.pos;
@@ -441,33 +434,31 @@ Tri TriToEllipsoidSpace(Tri tri, glm::mat3 toESPace) {
 
 CollisionInfo PushTouch(EllipsoidCollider ec, glm::vec3 velocity, MapTri* tris, int triCount) {
     std::vector<Tri> esTris;
-    for (int i = 0; i < triCount; i++) {
-        Tri tri = tris[ i ].tri;
+    for ( int i = 0; i < triCount; i++ ) {
+        Tri tri   = tris[ i ].tri;
         Tri esTri = TriToEllipsoidSpace(tri, ec.toESpace);
         esTris.push_back(esTri);
-    }  
-    glm::vec3 esBasePos = ec.toESpace * ec.center;
+    }
+    glm::vec3 esBasePos  = ec.toESpace * ec.center;
     glm::vec3 esVelocity = ec.toESpace * velocity;
 
     CollisionInfo ci;
-    ci.didCollide = false;
+    ci.didCollide      = false;
     ci.nearestDistance = 0.0f;
-    ci.velocity = esVelocity;
-    ci.hitPoint = glm::vec3(0.0f);
-    ci.basePos = esBasePos;
-   
-    for (int i = 0; i < triCount; i++) {
-        CollideUnitSphereWithTri( &ci, esTris[ i ] );
-        if (ci.didCollide) {
+    ci.velocity        = esVelocity;
+    ci.hitPoint        = glm::vec3(0.0f);
+    ci.basePos         = esBasePos;
+
+    for ( int i = 0; i < triCount; i++ ) {
+        CollideUnitSphereWithTri(&ci, esTris[ i ]);
+        if ( ci.didCollide ) {
             break;
         }
     }
 
-    glm::mat3 invESpace = glm::inverse( ec.toESpace );
-    ci.hitPoint = invESpace * ci.hitPoint;
-    ci.velocity = invESpace * ci.velocity;
+    glm::mat3 invESpace = glm::inverse(ec.toESpace);
+    ci.hitPoint         = invESpace * ci.hitPoint;
+    ci.velocity         = invESpace * ci.velocity;
 
     return ci;
 }
-
-

--- a/collision.h
+++ b/collision.h
@@ -6,16 +6,16 @@
 #define _COLLISION_H_
 
 #define GLM_FORCE_RADIANS
-#include "dependencies/glm/glm.hpp"
 #include "dependencies/glm/ext.hpp"
+#include "dependencies/glm/glm.hpp"
 
 #include "r_common.h"
 
 struct EllipsoidCollider {
-    glm::vec3   center;  // Pos in worldspace
-    float       radiusA; // horizontal radius
-    float       radiusB; // vertical radius
-    glm::mat3   toESpace; // Maps from World to ellipsoid (unit-sphere) space
+    glm::vec3 center;   // Pos in worldspace
+    float     radiusA;  // horizontal radius
+    float     radiusB;  // vertical radius
+    glm::mat3 toESpace; // Maps from World to ellipsoid (unit-sphere) space
 };
 
 struct CollisionInfo {
@@ -27,18 +27,19 @@ struct CollisionInfo {
 };
 
 EllipsoidCollider CreateEllipsoidColliderFromAABB(glm::vec3 mins, glm::vec3 maxs);
-void CollideUnitSphereWithPlane(CollisionInfo* ci, glm::vec3 pos, Plane p, Tri tri);
-glm::vec3 CollideEllipsoidWithTrisRec(CollisionInfo* ci, glm::vec3 esBasePos, glm::vec3 velocity, Tri* tris, int triCount, int depth, int maxDepth);
-CollisionInfo CollideEllipsoidWithMapTris(EllipsoidCollider ec, 
-                                          glm::vec3 velocity, 
-                                          glm::vec3 gravity, 
-                                          MapTri* tris, int triCount,
-                                          std::vector< std::vector<MapTri>* > brushMapTris);
-Tri  TriToEllipsoidSpace(Tri tri, glm::mat3 toESPace);
-Plane CreatePlaneFromTri(Tri tri);
-bool IsPointInTriangle(glm::vec3 point, Tri tri, glm::vec3 triNormal);
+void              CollideUnitSphereWithPlane(CollisionInfo* ci, glm::vec3 pos, Plane p, Tri tri);
+glm::vec3         CollideEllipsoidWithTrisRec(
+            CollisionInfo* ci, glm::vec3 esBasePos, glm::vec3 velocity, Tri* tris, int triCount, int depth, int maxDepth);
+CollisionInfo CollideEllipsoidWithMapTris(EllipsoidCollider                 ec,
+                                          glm::vec3                         velocity,
+                                          glm::vec3                         gravity,
+                                          MapTri*                           tris,
+                                          int                               triCount,
+                                          std::vector<std::vector<MapTri>*> brushMapTris);
+Tri           TriToEllipsoidSpace(Tri tri, glm::mat3 toESPace);
+Plane         CreatePlaneFromTri(Tri tri);
+bool          IsPointInTriangle(glm::vec3 point, Tri tri, glm::vec3 triNormal);
 // PushTouch will *only* trigger a collision if the ellipsoid is moving by a non-zero velocity vector.
 CollisionInfo PushTouch(EllipsoidCollider ec, glm::vec3 velocity, MapTri* tris, int triCount);
 
 #endif // _COLLISION_H_
-

--- a/command.cpp
+++ b/command.cpp
@@ -1,6 +1,3 @@
 #include "command.h"
 
 #include <stdio.h>
-
-
-

--- a/command.h
+++ b/command.h
@@ -3,17 +3,13 @@
 
 class Command {
 
-public:
-
-    Command() = default;
+  public:
+    Command()  = default;
     ~Command() = default;
 
     virtual void Execute() = 0;
 
-private:
-
+  private:
 };
 
-
 #endif
-

--- a/commands.cpp
+++ b/commands.cpp
@@ -5,7 +5,7 @@
 
 JumpCmd* JumpCmd::Instance() {
     static JumpCmd m_Cmd;
-    
+
     return &m_Cmd;
 }
 
@@ -15,11 +15,10 @@ void JumpCmd::Execute() {
 
 UseCmd* UseCmd::Instance() {
     static UseCmd m_Cmd;
-    
+
     return &m_Cmd;
 }
 
 void UseCmd::Execute() {
     printf("Using...\n");
 }
-

--- a/commands.h
+++ b/commands.h
@@ -4,26 +4,25 @@
 #include "command.h"
 
 class JumpCmd : public Command {
-public:
+  public:
     static JumpCmd* Instance();
 
     void Execute() override;
 
-private:
-    JumpCmd() = default;
+  private:
+    JumpCmd()  = default;
     ~JumpCmd() = default;
 };
 
 class UseCmd : public Command {
-public:
+  public:
     static UseCmd* Instance();
 
     void Execute() override;
 
-private:
-    UseCmd() = default;
+  private:
+    UseCmd()  = default;
     ~UseCmd() = default;
 };
 
 #endif
-

--- a/game.cpp
+++ b/game.cpp
@@ -37,8 +37,8 @@ static int hkd_Clamp(int val, int clamp) {
 }
 
 Game::Game(std::string exePath, hkdInterface* pInterface) {
-    m_pInterface = pInterface;
-    m_ExePath = exePath;
+    m_pInterface     = pInterface;
+    m_ExePath        = exePath;
     m_pEntityManager = EntityManager::Instance();
 }
 
@@ -49,7 +49,7 @@ void Game::Init() {
     VariableManager::Register(&dbg_show_enemy_velocity);
 
     // Load a font file from disk
-    m_ConsoleFont = new CFont("fonts/HackNerdFont-Bold.ttf", 72);
+    m_ConsoleFont   = new CFont("fonts/HackNerdFont-Bold.ttf", 72);
     m_ConsoleFont30 = new CFont("fonts/HackNerdFont-Bold.ttf", 150); // Same font at different size
 
     IRender* renderer = GetRenderer();
@@ -69,7 +69,7 @@ void Game::Init() {
 #endif
 
     size_t inputLength = mapData.length();
-    Map map = getMap(&mapData[ 0 ], inputLength, mapVersion);
+    Map    map         = getMap(&mapData[ 0 ], inputLength, mapVersion);
 
     m_World = CWorld::Instance();
     m_World->InitWorldFromMap(map);
@@ -79,43 +79,43 @@ void Game::Init() {
     // Creates batches for each texture-name. That way we can
     // reduce draw-calls and texture-binds when rendering world geometry.
 
-    renderer->RegisterWorld( m_World);
+    renderer->RegisterWorld(m_World);
 
     //m_pPlayerEntity = new Player(idCounter++, m_pPlayerEntity->m_Position);
     //m_pEntityManager->RegisterEntity(m_pPlayerEntity);
- 
+
 #if 0 // Enable second debug player
     glm::vec3 dbgPlayerStartPos = m_pPlayerEntity->m_Position + glm::vec3(20.0f, -100.0f, 10.0f);
     m_pDebugPlayerEntity = new Player(dbgPlayerStartPos);
     printf("Debug Player Start Pos: %f, %f, %f\n", dbgPlayerStartPos.x, dbgPlayerStartPos.y, dbgPlayerStartPos.z);
     m_pEntityManager->RegisterEntity(m_pDebugPlayerEntity);
     int hDebugPlayerModel = renderer->RegisterModel(m_pDebugPlayerEntity->GetModel());
-#endif 
+#endif
 
-    m_pFlyCameraEntity = new CFlyCamera( glm::vec3(-912, -586, 609) );
+    m_pFlyCameraEntity = new CFlyCamera(glm::vec3(-912, -586, 609));
     m_pFlyCameraEntity->m_Camera.RotateAroundSide(-45.0f);
     m_pFlyCameraEntity->m_Camera.RotateAroundUp(180.0f);
-  
+
     // FIX: If the follow camera is registered *before* one of the entities
     // the follow camera will lag behind one frame because it won't
     // get the most up to date position of its target!
     // We can choose to have a dedicated array for all of the
     // camera entity types and let the entity manager take care
     // of correct update order.
-    m_pFollowCameraEntity = new CFollowCamera(m_pPlayerEntity);
+    m_pFollowCameraEntity           = new CFollowCamera(m_pPlayerEntity);
     m_pFollowCameraEntity->m_Camera = Camera(m_pPlayerEntity->m_Position);
     m_pFollowCameraEntity->m_Camera.m_Pos.y -= 200.0f;
     m_pFollowCameraEntity->m_Camera.m_Pos.z += 100.0f;
     m_pFollowCameraEntity->m_Camera.RotateAroundSide(0.0f);
     //m_pFollowCameraEntity->m_Camera.RotateAroundUp(180.0f);
     m_pEntityManager->RegisterEntity(m_pFollowCameraEntity);
-   
+
     // Upload this model to the GPU. This will add the model to the model-batch and you get an ID where to find the data
     // in the batch?
 
     //int hPlayerModel = renderer->RegisterModel(m_pPlayerEntity->GetModel());
     //
-   
+
     // Test Input Binding
 
     // Keyboard buttons
@@ -131,8 +131,8 @@ void Game::Init() {
     inputHandler->BindInputToActionName(SDLK_LEFT, "turn_left");
     inputHandler->BindInputToActionName(SDLK_RIGHT, "turn_right");
     // Mouse buttons
-    inputHandler->BindInputToActionName(SDL_BUTTON_LEFT, "fire"); 
-    inputHandler->BindInputToActionName(SDL_BUTTON_RIGHT, "look"); 
+    inputHandler->BindInputToActionName(SDL_BUTTON_LEFT, "fire");
+    inputHandler->BindInputToActionName(SDL_BUTTON_RIGHT, "look");
 
     // Let the player receive input by default
     CInputDelegate::Instance()->SetReceiver(m_pPlayerEntity);
@@ -140,16 +140,16 @@ void Game::Init() {
 
 static void DrawCoordinateSystem(IRender* renderer) {
     Vertex origin = { glm::vec3(0.0f) };
-    origin.color = glm::vec4(1.0f);
-    Vertex X = { glm::vec3(100.0f, 0.0f, 0.0f) };
-    X.color = glm::vec4(1.0f, 0.0f, 0.0f, 1.0f);
-    Vertex Y = { glm::vec3(0.0f, 100.0f, 0.0f) };
-    Y.color = glm::vec4(0.0f, 1.0f, 0.0f, 1.0f);
-    Vertex Z = { glm::vec3(0.0f, 0.0f, 100.0f) };
-    Z.color = glm::vec4(0.0f, 0.0f, 1.0f, 1.0f);
-    Vertex OX[] = { origin, X };
-    Vertex OY[] = { origin, Y };
-    Vertex OZ[] = { origin, Z };
+    origin.color  = glm::vec4(1.0f);
+    Vertex X      = { glm::vec3(100.0f, 0.0f, 0.0f) };
+    X.color       = glm::vec4(1.0f, 0.0f, 0.0f, 1.0f);
+    Vertex Y      = { glm::vec3(0.0f, 100.0f, 0.0f) };
+    Y.color       = glm::vec4(0.0f, 1.0f, 0.0f, 1.0f);
+    Vertex Z      = { glm::vec3(0.0f, 0.0f, 100.0f) };
+    Z.color       = glm::vec4(0.0f, 0.0f, 1.0f, 1.0f);
+    Vertex OX[]   = { origin, X };
+    Vertex OY[]   = { origin, Y };
+    Vertex OZ[]   = { origin, Z };
     renderer->ImDrawLines(OX, 2);
     renderer->ImDrawLines(OY, 2);
     renderer->ImDrawLines(OZ, 2);
@@ -164,22 +164,22 @@ bool Game::RunFrame(double dt) {
         m_pInterface->QuitGame();
     }
 
-    // Toggle who should be controlled by the input system 
-    static IInputReceiver* receivers[2] = { m_pPlayerEntity, m_pFlyCameraEntity };
-    static BaseGameEntity* entities[2] = { m_pPlayerEntity, m_pFlyCameraEntity };
-    static Camera* renderCam = &m_pFollowCameraEntity->m_Camera;
+    // Toggle who should be controlled by the input system
+    static IInputReceiver* receivers[ 2 ] = { m_pPlayerEntity, m_pFlyCameraEntity };
+    static BaseGameEntity* entities[ 2 ]  = { m_pPlayerEntity, m_pFlyCameraEntity };
+    static Camera*         renderCam      = &m_pFollowCameraEntity->m_Camera;
 
     // Toggle receivers
     static int receiverToggle = 0;
     if ( KeyWentDown(SDLK_u) ) {
         printf("Switching to receiver num: %d\n", receiverToggle);
         receiverToggle = ++receiverToggle % 2;
-        CInputDelegate::Instance()->SetReceiver( receivers[ receiverToggle ] ); 
-        m_pFollowCameraEntity->SetTarget( entities[ receiverToggle ] );
+        CInputDelegate::Instance()->SetReceiver(receivers[ receiverToggle ]);
+        m_pFollowCameraEntity->SetTarget(entities[ receiverToggle ]);
         renderCam = &m_pFollowCameraEntity->m_Camera;
         if ( entities[ receiverToggle ]->Type() == ET_FLY_CAMERA ) {
             CFlyCamera* flyCamEnt = (CFlyCamera*)entities[ receiverToggle ];
-            renderCam = &flyCamEnt->m_Camera;
+            renderCam             = &flyCamEnt->m_Camera;
         }
     }
     // Handle the input
@@ -190,7 +190,6 @@ bool Game::RunFrame(double dt) {
 
     // Check if player has contacts with other entities (including brush entities such as doors).
     m_World->CollideEntities();
-
 
     // Run the message system
     m_pEntityManager->UpdateEntities();
@@ -221,15 +220,15 @@ bool Game::RunFrame(double dt) {
             // Draw Debug Circle for enemy
             glm::vec3 center = enemy->m_Position + enemy->m_Forward * enemy->m_pSteeringBehaviour->m_WanderDistance;
             renderer->ImDrawCircle(center, enemy->m_pSteeringBehaviour->m_WanderRadius, DOD_WORLD_UP);
-        
-        // Draw Debug Line for player veloctiy vector
+
+            // Draw Debug Line for player veloctiy vector
             Line velocityDebugLine = {
                 Vertex(center),
                 Vertex(enemy->m_pSteeringBehaviour->m_WanderTarget) //* enemy->m_pSteeringBehaviour->m_WanderRadius
             };
-        velocityDebugLine.a.color = glm::vec4(1.0f, 1.0f, 0.0f, 1.0f);
-        velocityDebugLine.b.color = velocityDebugLine.a.color;
-        renderer->ImDrawLines(velocityDebugLine.vertices, 2, false);
+            velocityDebugLine.a.color = glm::vec4(1.0f, 1.0f, 0.0f, 1.0f);
+            velocityDebugLine.b.color = velocityDebugLine.a.color;
+            renderer->ImDrawLines(velocityDebugLine.vertices, 2, false);
         }
         // Render World Geometry (Batched triangles)
         //renderer->SetActiveCamera(&m_FollowCamera);
@@ -248,13 +247,14 @@ bool Game::RunFrame(double dt) {
 #endif
 
 #if 1 // Toggle moving entity rendering. Also renders world.
-        renderer->Render(renderCam, 
-                         m_World->GetModelPtrs().data(), m_World->GetModelPtrs().size(),
-                         m_World->GetBrushModelPtrs().data(), m_World->GetBrushModelPtrs().size());
+        renderer->Render(renderCam,
+                         m_World->GetModelPtrs().data(),
+                         m_World->GetModelPtrs().size(),
+                         m_World->GetBrushModelPtrs().data(),
+                         m_World->GetBrushModelPtrs().size());
 #endif
 
         // auto type = enemy->m_Type;
-
 
 #if 0
         if ( collisionInfo.didCollide ) {
@@ -272,7 +272,7 @@ bool Game::RunFrame(double dt) {
         //renderer->SetActiveCamera(&m_pFlyCameraEntity->m_Camera);
         HKD_Model* playerColliderModel[] = { m_pPlayerEntity->GetModel() };
         renderer->RenderColliders(renderCam, playerColliderModel, 1);
-        
+
         renderer->End3D();
     } // End3D scope
 
@@ -321,7 +321,6 @@ bool Game::RunFrame(double dt) {
     } // End2D Scope
 #endif
 
-
     return true;
 }
 
@@ -333,4 +332,3 @@ void Game::Shutdown() {
     // delete m_pEntityManager;
     m_pEntityManager->KillEntities();
 }
-

--- a/game.h
+++ b/game.h
@@ -6,9 +6,9 @@
 #include "CWorld.h"
 #include "Entity/Door/g_door.h"
 #include "Entity/Enemy/g_enemy.h"
-#include "Entity/Player/g_player.h"
-#include "Entity/FollowCamera/g_follow_camera.h"
 #include "Entity/FlyCamera/g_fly_camera.h"
+#include "Entity/FollowCamera/g_follow_camera.h"
+#include "Entity/Player/g_player.h"
 #include "Entity/entity_manager.h"
 #include "Path/path.h"
 #include "camera.h"
@@ -17,34 +17,33 @@
 
 class Game {
   public:
-    Game(std::string exePath, hkdInterface *pInterface);
+    Game(std::string exePath, hkdInterface* pInterface);
 
     void Init();
     bool RunFrame(double dt);
     void Shutdown();
 
   private:
-    hkdInterface*               m_pInterface;
-    std::string                 m_ExePath;
+    hkdInterface* m_pInterface;
+    std::string   m_ExePath;
 
-    Player*                     m_pPlayerEntity;
-    Player*                     m_pDebugPlayerEntity; // Entity we can fly around with
-    Enemy*                      m_pEnemyEntity;
-    CFlyCamera*                 m_pFlyCameraEntity;
-    CFollowCamera*              m_pFollowCameraEntity; 
-    EntityManager*              m_pEntityManager;
+    Player*        m_pPlayerEntity;
+    Player*        m_pDebugPlayerEntity; // Entity we can fly around with
+    Enemy*         m_pEnemyEntity;
+    CFlyCamera*    m_pFlyCameraEntity;
+    CFollowCamera* m_pFollowCameraEntity;
+    EntityManager* m_pEntityManager;
 
-    Camera                      m_Camera;
+    Camera m_Camera;
 
-    std::vector<HKD_Model*>     m_Models;
-    CFont*                      m_ConsoleFont;
-    CFont*                      m_ConsoleFont30;
-    Box                         m_SkyBox{};
+    std::vector<HKD_Model*> m_Models;
+    CFont*                  m_ConsoleFont;
+    CFont*                  m_ConsoleFont30;
+    Box                     m_SkyBox{};
 
-    double                      m_AccumTime;
+    double m_AccumTime;
 
-    CWorld*                     m_World;
+    CWorld* m_World;
 };
 
 #endif
-

--- a/globals.h
+++ b/globals.h
@@ -1,10 +1,9 @@
 #ifndef _GLOBALS_H_
 #define _GLOBALS_H_
 
-
 #define GLM_FORCE_RADIANS
-#include "../../dependencies/glm/glm.hpp"
 #include "../../dependencies/glm/ext.hpp"
+#include "../../dependencies/glm/glm.hpp"
 #include "../../dependencies/glm/gtx/quaternion.hpp"
 
 constexpr glm::vec3 DOD_WORLD_UP(0.0f, 0.0f, 1.0f);
@@ -12,5 +11,3 @@ constexpr glm::vec3 DOD_WORLD_FORWARD(0.0f, 1.0f, 0.0f);
 constexpr glm::vec3 DOD_WORLD_RIGHT(1.0f, 0.0f, 0.0f);
 
 #endif
-
-

--- a/hkd_interface.h
+++ b/hkd_interface.h
@@ -14,5 +14,4 @@ struct hkdInterface {
 
 IRender* GetRenderer();
 
-
 #endif

--- a/image.cpp
+++ b/image.cpp
@@ -13,7 +13,7 @@ extern std::string g_GameDir;
 CImage::CImage(std::string filename) {
 
     std::string filePath = g_GameDir + filename; // TODO: File system functions.
-    int x, y, n;
+    int         x, y, n;
     m_Pixeldata = stbi_load(filePath.c_str(), &x, &y, &n, 4);
 
     // TODO: We probably should load a checkerboard texture or a
@@ -22,22 +22,22 @@ CImage::CImage(std::string filename) {
     if ( !m_Pixeldata ) {
         printf("WARNING (CImage): Failed to load image: %s\n", filename.c_str());
 
-	return;
+        return;
     }
 
-    m_Width = x;
-    m_Height = y;
+    m_Width    = x;
+    m_Height   = y;
     m_Channels = n;
-    m_Valid = true;
+    m_Valid    = true;
     m_Filename = filename;
 }
 
 void CImage::FreePixeldata() {
     if ( !m_Pixeldata ) {
-	return;
+        return;
     }
-    
-    stbi_image_free( m_Pixeldata );
+
+    stbi_image_free(m_Pixeldata);
 }
 
 // Ugh...
@@ -60,4 +60,3 @@ int CImage::Channels() {
 bool CImage::Valid() {
     return m_Valid;
 }
-

--- a/image.h
+++ b/image.h
@@ -7,27 +7,25 @@
 
 class CImage {
 
-public:
+  public:
     CImage(std::string filename);
     ~CImage() {}; // NOTE: User is responsible to unload the image!
 
     void FreePixeldata();
 
-    unsigned char*  Pixels();
-    int             Width();
-    int             Height();
-    int             Channels();
-    bool            Valid();
+    unsigned char* Pixels();
+    int            Width();
+    int            Height();
+    int            Channels();
+    bool           Valid();
 
-
-private:
-    unsigned char*  m_Pixeldata = nullptr;
-    int             m_Width = 0;
-    int             m_Height = 0;
-    int             m_Channels = 0;
-    bool            m_Valid = false;
-    std::string     m_Filename;
+  private:
+    unsigned char* m_Pixeldata = nullptr;
+    int            m_Width     = 0;
+    int            m_Height    = 0;
+    int            m_Channels  = 0;
+    bool           m_Valid     = false;
+    std::string    m_Filename;
 };
 
 #endif
-

--- a/input.cpp
+++ b/input.cpp
@@ -5,100 +5,95 @@
 #include <SDL.h>
 
 #include "imgui.h"
-#include <imgui/backends/imgui_impl_sdl2.h>
 #include <imgui/backends/imgui_impl_opengl3.h>
+#include <imgui/backends/imgui_impl_sdl2.h>
 
-static Uint32       g_Events;
-static bool         g_Scancodes[SDL_NUM_SCANCODES];
-static bool         g_PrevScancodes[SDL_NUM_SCANCODES];
-static bool         g_PerFrameScancodes[SDL_NUM_SCANCODES];
-static Uint8        g_MouseButtons;
-static Uint8        g_PrevMouseButtons;
-static MouseMotion  g_MouseMotionState;
-static MouseWheel   g_MouseWheelState;
+static Uint32      g_Events;
+static bool        g_Scancodes[ SDL_NUM_SCANCODES ];
+static bool        g_PrevScancodes[ SDL_NUM_SCANCODES ];
+static bool        g_PerFrameScancodes[ SDL_NUM_SCANCODES ];
+static Uint8       g_MouseButtons;
+static Uint8       g_PrevMouseButtons;
+static MouseMotion g_MouseMotionState;
+static MouseWheel  g_MouseWheelState;
 
 static std::string g_EventText;
 
-void HandleInput(void)
-{
+void HandleInput(void) {
     memcpy(g_PrevScancodes, g_Scancodes, SDL_NUM_SCANCODES * sizeof(bool));
     g_PrevMouseButtons = g_MouseButtons;
     memset(g_PerFrameScancodes, 0, SDL_NUM_SCANCODES * sizeof(bool));
 
-    g_Events = 0;
-    g_EventText = "";
+    g_Events                  = 0;
+    g_EventText               = "";
     g_MouseWheelState.updated = false;
 
     SDL_Event event;
-    while (SDL_PollEvent(&event)) {
+    while ( SDL_PollEvent(&event) ) {
 
         ImGui_ImplSDL2_ProcessEvent(&event);
 
-        if (event.type == SDL_QUIT) {
+        if ( event.type == SDL_QUIT ) {
             g_Events |= SDL_QUIT;
         }
-        if (event.type == SDL_WINDOWEVENT) {
+        if ( event.type == SDL_WINDOWEVENT ) {
             g_Events |= SDL_WINDOWEVENT;
         }
 
-        if (event.type == SDL_KEYDOWN) {
-            g_Scancodes[event.key.keysym.scancode] = true;
-            g_PerFrameScancodes[event.key.keysym.scancode] = true;
+        if ( event.type == SDL_KEYDOWN ) {
+            g_Scancodes[ event.key.keysym.scancode ]         = true;
+            g_PerFrameScancodes[ event.key.keysym.scancode ] = true;
         }
-        if (event.type == SDL_KEYUP) {
-            g_Scancodes[event.key.keysym.scancode] = false;
-            g_PerFrameScancodes[event.key.keysym.scancode] = false;
+        if ( event.type == SDL_KEYUP ) {
+            g_Scancodes[ event.key.keysym.scancode ]         = false;
+            g_PerFrameScancodes[ event.key.keysym.scancode ] = false;
         }
 
-        if (event.type == SDL_MOUSEBUTTONDOWN) {
+        if ( event.type == SDL_MOUSEBUTTONDOWN ) {
             g_MouseButtons |= SDL_BUTTON(event.button.button);
         }
-        if (event.type == SDL_MOUSEBUTTONUP) {
+        if ( event.type == SDL_MOUSEBUTTONUP ) {
             g_MouseButtons ^= SDL_BUTTON(event.button.button);
         }
-        if (event.type == SDL_MOUSEMOTION) {
-            g_MouseMotionState.prev = g_MouseMotionState.current;
+        if ( event.type == SDL_MOUSEMOTION ) {
+            g_MouseMotionState.prev    = g_MouseMotionState.current;
             g_MouseMotionState.current = event.motion;
         }
-        if (event.type == SDL_MOUSEWHEEL) {
-            g_MouseWheelState.prev = g_MouseWheelState.current;
+        if ( event.type == SDL_MOUSEWHEEL ) {
+            g_MouseWheelState.prev    = g_MouseWheelState.current;
             g_MouseWheelState.current = event.wheel;
             g_MouseWheelState.updated = true;
         }
-        
-        if (event.type == SDL_TEXTINPUT) {
+
+        if ( event.type == SDL_TEXTINPUT ) {
             auto str = std::string(event.text.text);
-            if (str.length() == 1) g_EventText = str; // ignore unicode characters (length > 1)
+            if ( str.length() == 1 ) g_EventText = str; // ignore unicode characters (length > 1)
         }
     }
 }
 
-bool KeyWentDown(SDL_Keycode keyCode)
-{
+bool KeyWentDown(SDL_Keycode keyCode) {
     SDL_Scancode sc = SDL_GetScancodeFromKey(keyCode);
-    return (!g_PrevScancodes[sc] && g_Scancodes[sc]);
+    return (!g_PrevScancodes[ sc ] && g_Scancodes[ sc ]);
 }
 
 bool KeyWentDownUnbuffered(SDL_Keycode keyCode) {
     SDL_Scancode sc = SDL_GetScancodeFromKey(keyCode);
-    return g_PerFrameScancodes[sc];
+    return g_PerFrameScancodes[ sc ];
 }
 
-bool KeyWentUp(SDL_Keycode keyCode)
-{
+bool KeyWentUp(SDL_Keycode keyCode) {
     SDL_Scancode sc = SDL_GetScancodeFromKey(keyCode);
-    return (g_PrevScancodes[sc] && !g_Scancodes[sc]);
+    return (g_PrevScancodes[ sc ] && !g_Scancodes[ sc ]);
 }
 
-bool KeyPressed(SDL_Keycode keyCode)
-{
+bool KeyPressed(SDL_Keycode keyCode) {
     SDL_Scancode sc = SDL_GetScancodeFromKey(keyCode);
-    return (g_PrevScancodes[sc] && g_Scancodes[sc]);
+    return (g_PrevScancodes[ sc ] && g_Scancodes[ sc ]);
 }
 
-bool MouseWentDown(int button)
-{
-    if (button > SDL_BUTTON_RIGHT || button < SDL_BUTTON_LEFT) {
+bool MouseWentDown(int button) {
+    if ( button > SDL_BUTTON_RIGHT || button < SDL_BUTTON_LEFT ) {
         return false;
     }
     Uint8 uButton = (Uint8)button;
@@ -106,28 +101,25 @@ bool MouseWentDown(int button)
     return (!(g_PrevMouseButtons & SDL_BUTTON(uButton)) && (g_MouseButtons & SDL_BUTTON(uButton)));
 }
 
-bool MouseWentUp(int button)
-{
-    if (button > SDL_BUTTON_RIGHT || button < SDL_BUTTON_LEFT) {
+bool MouseWentUp(int button) {
+    if ( button > SDL_BUTTON_RIGHT || button < SDL_BUTTON_LEFT ) {
         return false;
     }
     Uint8 uButton = (Uint8)button;
-    
+
     return ((g_PrevMouseButtons & SDL_BUTTON(uButton)) && !(g_MouseButtons & SDL_BUTTON(uButton)));
 }
 
-bool MousePressed(int button)
-{
-    if (button > SDL_BUTTON_RIGHT || button < SDL_BUTTON_LEFT) {
+bool MousePressed(int button) {
+    if ( button > SDL_BUTTON_RIGHT || button < SDL_BUTTON_LEFT ) {
         return false;
     }
     Uint8 uButton = (Uint8)button;
-    
+
     return g_MouseButtons & SDL_BUTTON(uButton);
 }
 
-bool RightMouseWentDown(void)
-{
+bool RightMouseWentDown(void) {
     return false;
 }
 
@@ -139,18 +131,14 @@ const MouseWheel GetMouseWheel(void) {
     return g_MouseWheelState;
 }
 
-bool ShouldClose(void)
-{    
+bool ShouldClose(void) {
     return g_Events & SDL_QUIT;
 }
 
-const std::string& TextInput()
-{
+const std::string& TextInput() {
     return g_EventText;
 }
 
 void ClearTextInput() {
     g_EventText = "";
 }
-
-

--- a/input.h
+++ b/input.h
@@ -14,7 +14,7 @@ struct MouseMotion {
 struct MouseWheel {
     SDL_MouseWheelEvent current;
     SDL_MouseWheelEvent prev;
-    bool updated;
+    bool                updated;
 };
 
 void HandleInput(void);
@@ -29,18 +29,17 @@ bool KeyWentDown(SDL_Keycode keyCode);
 */
 bool KeyWentDownUnbuffered(SDL_Keycode keyCode);
 
-bool KeyWentUp(SDL_Keycode keyCode);
-bool KeyPressed(SDL_Keycode keyCode);
-bool MouseWentDown(int button);
-bool MouseWentUp(int button);
-bool MousePressed(int button);
-bool RightMouseWentDown(void);
+bool              KeyWentUp(SDL_Keycode keyCode);
+bool              KeyPressed(SDL_Keycode keyCode);
+bool              MouseWentDown(int button);
+bool              MouseWentUp(int button);
+bool              MousePressed(int button);
+bool              RightMouseWentDown(void);
 const MouseMotion GetMouseMotion(void);
-const MouseWheel GetMouseWheel(void);
-bool ShouldClose(void);
+const MouseWheel  GetMouseWheel(void);
+bool              ShouldClose(void);
 
-const std::string&  TextInput();
-void                ClearTextInput();
+const std::string& TextInput();
+void               ClearTextInput();
 
 #endif
-

--- a/input_delegate.cpp
+++ b/input_delegate.cpp
@@ -27,6 +27,3 @@ void CInputDelegate::Enable() {
 void CInputDelegate::Disable() {
     m_Enabled = false;
 }
-
-
-

--- a/input_delegate.h
+++ b/input_delegate.h
@@ -5,7 +5,7 @@
 
 class CInputDelegate {
 
-public:
+  public:
     static CInputDelegate* Instance();
 
     void SetReceiver(IInputReceiver* receiver);
@@ -17,14 +17,13 @@ public:
     void Enable();
     void Disable();
 
-private:
+  private:
     /* Singleton! */
     CInputDelegate()  = default;
     ~CInputDelegate() = default;
 
     IInputReceiver* m_InputReceiver = nullptr;
-    bool            m_Enabled = true;
+    bool            m_Enabled       = true;
 };
 
 #endif
-

--- a/input_handler.cpp
+++ b/input_handler.cpp
@@ -12,11 +12,11 @@ CInputHandler* CInputHandler::Instance() {
 }
 
 void CInputHandler::BindInputToActionName(int key, const std::string& actionName) {
-    m_ActionNameToInput.insert({ actionName, key }); 
+    m_ActionNameToInput.insert({ actionName, key });
 }
 
 ButtonState CInputHandler::GetMappedButtonState(const std::string& actionName) {
-    // Check if a mapping exists for this action 
+    // Check if a mapping exists for this action
     const auto& actionToInput = m_ActionNameToInput.find(actionName);
     if ( actionToInput == m_ActionNameToInput.end() ) {
         return ButtonState::NONE;
@@ -48,4 +48,3 @@ ButtonState CInputHandler::GetMappedButtonState(const std::string& actionName) {
     // Action exists but no button is active in any way.
     return ButtonState::NONE;
 }
-

--- a/input_handler.h
+++ b/input_handler.h
@@ -3,8 +3,8 @@
 
 #include "command.h"
 
-#include <unordered_map>
 #include <string>
+#include <unordered_map>
 
 enum class ButtonState {
     NONE,
@@ -15,22 +15,20 @@ enum class ButtonState {
 
 class CInputHandler {
 
-public:
+  public:
     // Singleton class!
     static CInputHandler* Instance();
 
     void        BindInputToActionName(int key, const std::string& actionName);
-    ButtonState GetMappedButtonState(const std::string& actionName); 
+    ButtonState GetMappedButtonState(const std::string& actionName);
 
-private:
+  private:
     CInputHandler()  = default;
     ~CInputHandler() = default;
 
-    std::unordered_map<std::string, int>         m_ActionNameToInput;
-    
+    std::unordered_map<std::string, int> m_ActionNameToInput;
 };
 
 #define CHECK_ACTION(actionName) (CInputHandler::Instance()->GetMappedButtonState(actionName))
 
 #endif
-

--- a/input_receiver.h
+++ b/input_receiver.h
@@ -6,15 +6,11 @@
 */
 class IInputReceiver {
 
-public:
+  public:
     IInputReceiver()  = default;
     ~IInputReceiver() = default;
 
     virtual void HandleInput() = 0;
-
 };
 
-
 #endif
-
-

--- a/iqm_loader.h
+++ b/iqm_loader.h
@@ -7,12 +7,12 @@
 #include <stdint.h>
 
 #define GLM_FORCE_RADIANS
-#include "dependencies/glm/glm.hpp"
 #include "dependencies/glm/ext.hpp"
+#include "dependencies/glm/glm.hpp"
 
 struct IQMHeader {
-    uint8_t  magic[16]; // "INTERQUAKEMODEL\0"
-    uint32_t version;  // Must be version 2
+    uint8_t  magic[ 16 ]; // "INTERQUAKEMODEL\0"
+    uint32_t version;     // Must be version 2
     uint32_t filesize;
     uint32_t flags;
     uint32_t numText, ofsText;
@@ -37,29 +37,29 @@ struct IQMMeshData {
 // Default Vertex format
 
 struct IQMVertex {
-    float pos[3];
-    float texCoord[2];
-    float normal[3];
-    float tangent[4];
-    uint8_t blendindices[4];
-    uint8_t blendweights[4];
-    uint8_t color[4];
+    float   pos[ 3 ];
+    float   texCoord[ 2 ];
+    float   normal[ 3 ];
+    float   tangent[ 4 ];
+    uint8_t blendindices[ 4 ];
+    uint8_t blendweights[ 4 ];
+    uint8_t color[ 4 ];
 };
 
 // NOTE: Mesh, Pose and Anim structs are not part of IQM.
 //       Maybe move them out of here later or something.
 
 struct IQMMesh {
-    std::string             material;
-    std::vector<IQMVertex>  vertices;
-    uint32_t                firstTri, numTris;
+    std::string            material;
+    std::vector<IQMVertex> vertices;
+    uint32_t               firstTri, numTris;
 };
 
 struct Pose {
-    int32_t     parent;
-    glm::vec3   translations;
-    glm::vec3   scale;
-    glm::quat   rotation;
+    int32_t   parent;
+    glm::vec3 translations;
+    glm::vec3 scale;
+    glm::quat rotation;
 };
 
 struct Anim {
@@ -69,22 +69,22 @@ struct Anim {
 };
 
 struct Frame {
-    glm::vec3   bbmins;
-    glm::vec3   bbmaxs;
-    float       xyRadius;
-    float       sphericalRadius;
+    glm::vec3 bbmins;
+    glm::vec3 bbmaxs;
+    float     xyRadius;
+    float     sphericalRadius;
 };
 
 struct IQMModel {
-    std::string             filename;
-    std::vector<IQMMesh>    meshes;
-    std::vector<glm::mat4>  bindPoses;
-    std::vector<glm::mat4>  invBindPoses;
-    std::vector<Pose>       poses;
-    uint32_t                numJoints;
-    uint32_t                numFrames;
-    std::vector<Anim>       animations;
-    std::vector<Frame>      frameData; // Only holds bounding boxes
+    std::string            filename;
+    std::vector<IQMMesh>   meshes;
+    std::vector<glm::mat4> bindPoses;
+    std::vector<glm::mat4> invBindPoses;
+    std::vector<Pose>      poses;
+    uint32_t               numJoints;
+    uint32_t               numFrames;
+    std::vector<Anim>      animations;
+    std::vector<Frame>     frameData; // Only holds bounding boxes
 };
 
 struct IQMVertArray {
@@ -120,38 +120,37 @@ enum IQMVertArrayFormat {
 };
 
 struct IQMTri {
-    uint32_t vertex[3];
+    uint32_t vertex[ 3 ];
 };
 
 struct IQMJoint {
-    uint32_t    name;
-    int32_t     parent;
-    float       translate[3];
-    float       rotate[4];
-    float       scale[3];
+    uint32_t name;
+    int32_t  parent;
+    float    translate[ 3 ];
+    float    rotate[ 4 ];
+    float    scale[ 3 ];
 };
 
 struct IQMPose {
-    int32_t     parent;
-    uint32_t    channelmask;
-    float       channeloffset[10];
-    float       channelscale[10];
+    int32_t  parent;
+    uint32_t channelmask;
+    float    channeloffset[ 10 ];
+    float    channelscale[ 10 ];
 };
 
 struct IQMAnim {
-    uint32_t    name;
-    uint32_t    firstFrame, numFrames;
-    float       framerate;
-    uint32_t    flags;
+    uint32_t name;
+    uint32_t firstFrame, numFrames;
+    float    framerate;
+    uint32_t flags;
 };
 
 struct IQMBounds {
-    float bbmins[3];
-    float bbmaxs[3];
+    float bbmins[ 3 ];
+    float bbmaxs[ 3 ];
     float xyradius; // circular radius in xy-plane
     float radius;   // spherical radius
 };
-
 
 IQMModel LoadIQM(const char* file);
 void     UnloadIQM(IQMModel* iqmModel);

--- a/irender.h
+++ b/irender.h
@@ -4,75 +4,84 @@
 #ifndef _IRENDER_H_
 #define _IRENDER_H_
 
-#include <vector>
-#include <string>
 #include <stdint.h>
+#include <string>
+#include <vector>
 
-#include "r_itexture.h"
-#include "r_model.h"
+#include "CWorld.h"
+#include "Console/Console.h"
 #include "camera.h"
 #include "r_common.h"
 #include "r_font.h"
-#include "CWorld.h"
-#include "Console/Console.h"
+#include "r_itexture.h"
+#include "r_model.h"
 
 enum DrawMode {
-	DRAW_MODE_SOLID,
-	DRAW_MODE_WIREFRAME,
-	DRAW_MODE_LINES
+    DRAW_MODE_SOLID,
+    DRAW_MODE_WIREFRAME,
+    DRAW_MODE_LINES
 };
 
-struct GLBatchDrawCmd { // TODO: Rename
-	int		offset;		// offset into vertex buffer (VBO)
-	int		indexOffset;	// offset into index buffer (iVBO)
-	uint32_t	numVerts;
-	uint32_t	numIndices;
-	bool		cullFace;
-	DrawMode	drawMode;
+struct GLBatchDrawCmd {   // TODO: Rename
+    int      offset;      // offset into vertex buffer (VBO)
+    int      indexOffset; // offset into index buffer (iVBO)
+    uint32_t numVerts;
+    uint32_t numIndices;
+    bool     cullFace;
+    DrawMode drawMode;
 };
 
 class IRender {
-public:
-	virtual bool Init(void)			= 0;
-	virtual void Shutdown(void)		= 0;
-	virtual int  RegisterModel(HKD_Model* model) = 0;
-	virtual int  RegisterBrush(HKD_Model* model) = 0;
-	virtual void RegisterFont(CFont* font) = 0;
-	virtual void RegisterWorld(CWorld* world) = 0;
-	virtual uint64_t RegisterTextureGetHandle(std::string name) = 0;
-	virtual void SetActiveCamera(Camera* camera) = 0;
-	virtual std::vector<ITexture*> ModelTextures(int gpuModelHandle) = 0;
-	virtual std::vector<ITexture*> Textures() = 0;
-	virtual void ImDrawTris(Tri* tris, uint32_t numTris, bool cullFace = true, DrawMode drawMode = DRAW_MODE_SOLID) = 0;
-	virtual void ImDrawTriPlanes(TriPlane* triPlanes, uint32_t numTriPlanes, bool cullFace = true, DrawMode drawMode = DRAW_MODE_SOLID) = 0;
-	virtual void ImDrawIndexed(Vertex* verts, uint32_t numVerts, uint16_t* indices, uint32_t numIndices, bool cullFace = true, DrawMode drawMode = DRAW_MODE_SOLID) = 0;
-	virtual void ImDrawVerts(Vertex* verts, uint32_t numVerts) = 0;
-	virtual void ImDrawLines(Vertex* verts, uint32_t numVerts, bool close = false) = 0;
+  public:
+    virtual bool                   Init(void)                                                                       = 0;
+    virtual void                   Shutdown(void)                                                                   = 0;
+    virtual int                    RegisterModel(HKD_Model* model)                                                  = 0;
+    virtual int                    RegisterBrush(HKD_Model* model)                                                  = 0;
+    virtual void                   RegisterFont(CFont* font)                                                        = 0;
+    virtual void                   RegisterWorld(CWorld* world)                                                     = 0;
+    virtual uint64_t               RegisterTextureGetHandle(std::string name)                                       = 0;
+    virtual void                   SetActiveCamera(Camera* camera)                                                  = 0;
+    virtual std::vector<ITexture*> ModelTextures(int gpuModelHandle)                                                = 0;
+    virtual std::vector<ITexture*> Textures()                                                                       = 0;
+    virtual void ImDrawTris(Tri* tris, uint32_t numTris, bool cullFace = true, DrawMode drawMode = DRAW_MODE_SOLID) = 0;
+    virtual void ImDrawTriPlanes(TriPlane* triPlanes,
+                                 uint32_t  numTriPlanes,
+                                 bool      cullFace = true,
+                                 DrawMode  drawMode = DRAW_MODE_SOLID)
+        = 0;
+    virtual void ImDrawIndexed(Vertex*   verts,
+                               uint32_t  numVerts,
+                               uint16_t* indices,
+                               uint32_t  numIndices,
+                               bool      cullFace = true,
+                               DrawMode  drawMode = DRAW_MODE_SOLID)
+        = 0;
+    virtual void ImDrawVerts(Vertex* verts, uint32_t numVerts)                                                  = 0;
+    virtual void ImDrawLines(Vertex* verts, uint32_t numVerts, bool close = false)                              = 0;
     virtual void ImDrawCircle(glm::vec3 center, float radius, glm::vec3 normal)                                 = 0;
     virtual void ImDrawSphere(glm::vec3 pos, float radius, glm::vec4 color = glm::vec4(1.0f, 0.0f, 0.0f, 1.0f)) = 0;
-	virtual void RenderBegin(void) = 0;
-    virtual void Begin3D() = 0;
-	virtual void End3D() = 0;
-    virtual void DrawWorldTris() = 0;
-	virtual void Begin2D() = 0;
-	virtual void End2D() = 0;
-	virtual void SetFont(CFont* font, glm::vec4 color = glm::vec4(1.0f)) = 0; 
-	virtual void SetShapeColor(glm::vec4 color = glm::vec4(1.0f)) = 0;
-	virtual void FlushFonts() = 0;
-	virtual void FlushShapes() = 0;
-	virtual void R_DrawText(const std::string& text, float x, float y, ScreenSpaceCoordMode = COORD_MODE_REL) = 0;
-	virtual void DrawBox(float x, float y, float width, float height,
-					  ScreenSpaceCoordMode coordMode = COORD_MODE_REL) = 0;
-    virtual void Render(Camera* camera, 
-					 HKD_Model** models, uint32_t numModels,
-                     HKD_Model** brushModels, uint32_t numBrushModels) = 0;
-	virtual void RenderColliders(Camera* camera, HKD_Model** models, uint32_t numModels) = 0;
-	virtual void RenderConsole(Console* console, CFont* font) = 0;
-	virtual void RenderEnd(void) = 0;
-    virtual void SetWindowTitle(char* windowTitle)                                                              = 0;
+    virtual void RenderBegin(void)                                                                              = 0;
+    virtual void Begin3D()                                                                                      = 0;
+    virtual void End3D()                                                                                        = 0;
+    virtual void DrawWorldTris()                                                                                = 0;
+    virtual void Begin2D()                                                                                      = 0;
+    virtual void End2D()                                                                                        = 0;
+    virtual void SetFont(CFont* font, glm::vec4 color = glm::vec4(1.0f))                                        = 0;
+    virtual void SetShapeColor(glm::vec4 color = glm::vec4(1.0f))                                               = 0;
+    virtual void FlushFonts()                                                                                   = 0;
+    virtual void FlushShapes()                                                                                  = 0;
+    virtual void R_DrawText(const std::string& text, float x, float y, ScreenSpaceCoordMode = COORD_MODE_REL)   = 0;
+    virtual void DrawBox(float x, float y, float width, float height, ScreenSpaceCoordMode coordMode = COORD_MODE_REL)
+        = 0;
+    virtual void
+    Render(Camera* camera, HKD_Model** models, uint32_t numModels, HKD_Model** brushModels, uint32_t numBrushModels)
+        = 0;
+    virtual void RenderColliders(Camera* camera, HKD_Model** models, uint32_t numModels) = 0;
+    virtual void RenderConsole(Console* console, CFont* font)                            = 0;
+    virtual void RenderEnd(void)                                                         = 0;
+    virtual void SetWindowTitle(char* windowTitle)                                       = 0;
 
   private:
-
 };
 
 #endif

--- a/main.cpp
+++ b/main.cpp
@@ -6,9 +6,9 @@
 #include <Windows.h>
 #endif
 
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdint.h>
 
 #include <string>
 
@@ -16,12 +16,12 @@
 #include <glad/glad.h>
 
 #include "imgui.h"
-#include <imgui/backends/imgui_impl_sdl2.h>
 #include <imgui/backends/imgui_impl_opengl3.h>
+#include <imgui/backends/imgui_impl_sdl2.h>
 
 #define GLM_FORCE_RADIANS
-#include "dependencies/glm/glm.hpp"
 #include "dependencies/glm/ext.hpp"
+#include "dependencies/glm/glm.hpp"
 
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb_image.h"
@@ -29,22 +29,22 @@
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include "stb_image_write.h"
 
-#include "platform.h"
+#include "Console/VariableManager.h"
+#include "TestClass.h"
+#include "game.h"
+#include "hkd_interface.h"
+#include "input.h"
 #include "iqm_loader.h"
 #include "irender.h"
+#include "physics.h"
+#include "platform.h"
 #include "r_gl.h"
 #include "r_model.h"
-#include "input.h"
-#include "hkd_interface.h"
-#include "physics.h"
-#include "game.h"
-#include "TestClass.h"
 #include "utils/utils.h"
-#include "Console/VariableManager.h"
 
-static bool         g_GameWantsToQuit;
-std::string         g_GameDir;
-static IRender*     g_Renderer;
+static bool     g_GameWantsToQuit;
+std::string     g_GameDir;
+static IRender* g_Renderer;
 
 static bool QuitGameFunc(void) {
     g_GameWantsToQuit = true;
@@ -52,7 +52,7 @@ static bool QuitGameFunc(void) {
 }
 
 static double msPerFrame;
-double GetDeltaTime() {
+double        GetDeltaTime() {
     return msPerFrame;
 }
 
@@ -79,22 +79,21 @@ int main(int argc, char** argv) {
     // Init subsystems
 
     hkdInterface interface = {};
-    interface.QuitGame = QuitGameFunc;
+    interface.QuitGame     = QuitGameFunc;
 
     std::string exePath = hkd_GetExePath();
-    interface.gameDir = exePath;
-    g_GameDir = exePath;
-    if (argc > 1) {
-        interface.gameDir += std::string(argv[1]);
-        g_GameDir += std::string(argv[1]);
+    interface.gameDir   = exePath;
+    g_GameDir           = exePath;
+    if ( argc > 1 ) {
+        interface.gameDir += std::string(argv[ 1 ]);
+        g_GameDir += std::string(argv[ 1 ]);
     }
 
-
     g_Renderer = new GLRender();
-    if (!g_Renderer->Init()) {
+    if ( !g_Renderer->Init() ) {
         SDL_Log("Could not initialize renderer.\n");
         return -1;
-    }    
+    }
 
     VariableManager::Init();
     Console* console = Console::Create(100, 32);
@@ -102,32 +101,32 @@ int main(int argc, char** argv) {
     // Init the game
 
     Game game(exePath, &interface);
-    game.Init();    
-    
+    game.Init();
+
     // Main loop
-    
+
     Uint64 ticksPerSecond = SDL_GetPerformanceFrequency();
-    Uint64 startCounter = SDL_GetPerformanceCounter();
-    Uint64 endCounter = SDL_GetPerformanceCounter();
+    Uint64 startCounter   = SDL_GetPerformanceCounter();
+    Uint64 endCounter     = SDL_GetPerformanceCounter();
 
     float updateIntervalMs = 0.0f;
-    while (!ShouldClose() && !g_GameWantsToQuit) {
+    while ( !ShouldClose() && !g_GameWantsToQuit ) {
         double ticksPerFrame = (double)endCounter - (double)startCounter;
-        msPerFrame = (ticksPerFrame / (double)ticksPerSecond) * 1000.0;
+        msPerFrame           = (ticksPerFrame / (double)ticksPerSecond) * 1000.0;
 
         startCounter = SDL_GetPerformanceCounter();
 
         HandleInput();
-       
+
         g_Renderer->RenderBegin();
 
         // caret is not a standalone key in german keyboard layout (`KeyWentDown(SDLK_CARET)` doesn't work)
-        if (TextInput() == "^") {
-            console->m_isActive = !(console->m_isActive);
+        if ( TextInput() == "^" ) {
+            console->m_isActive   = !(console->m_isActive);
             console->m_blinkTimer = 0;
             ClearTextInput(); // Remove caret from the buffer
-        } 
-        if (console->m_isActive) {
+        }
+        if ( console->m_isActive ) {
             // FIXME: the game's 2d content disappears while console is open
             // NOTE: (Michael): We let this unfixed for now and defer this
             // to another time. To implement this cleanly a few things
@@ -144,18 +143,20 @@ int main(int argc, char** argv) {
 
         // This call composits 2D and 3D together into the default FBO
         // (along with ImGUI).
-        g_Renderer->RenderEnd(); 
-    
+        g_Renderer->RenderEnd();
+
         //printf("msPerFrame: %f\n", msPerFrame);
         //printf("FPS: %f\n", 1000.0f/msPerFrame);
 
         // Update window title every second.
         updateIntervalMs += msPerFrame;
-        if (updateIntervalMs >= 1000.0f) {
-            char windowTitle[256];
+        if ( updateIntervalMs >= 1000.0f ) {
+            char windowTitle[ 256 ];
             sprintf(windowTitle,
                     "Device: %s, frametime (ms): %f, FPS: %f",
-                    glGetString(GL_RENDERER), msPerFrame, 1000.0f / msPerFrame);
+                    glGetString(GL_RENDERER),
+                    msPerFrame,
+                    1000.0f / msPerFrame);
             g_Renderer->SetWindowTitle(windowTitle);
             updateIntervalMs = 0.0f;
         }
@@ -172,4 +173,3 @@ int main(int argc, char** argv) {
 
     return 0;
 }
-

--- a/map_parser.h
+++ b/map_parser.h
@@ -57,11 +57,11 @@ struct MapVertex {
 };
 
 struct Face {
-    MapVertex vertices[ 3 ]; // Define the plane.
+    MapVertex   vertices[ 3 ]; // Define the plane.
     std::string textureName;
-    double xOffset, yOffset;
-    double rotation;
-    double xScale, yScale;
+    double      xOffset, yOffset;
+    double      rotation;
+    double      xScale, yScale;
 
     // Valve 220 texture format
     double tx1, ty1, tz1, tOffset1;
@@ -79,7 +79,7 @@ struct Property {
 
 struct Entity {
     std::vector<Property> properties;
-    std::vector<Brush> brushes;
+    std::vector<Brush>    brushes;
 };
 
 struct Map {
@@ -96,8 +96,8 @@ Map getMap(char* mapData, size_t mapDataLength, MapVersion mapVersion = QUAKE);
 
 #ifdef MAP_PARSER_IMPLEMENTATION
 
-static int g_InputLength;
-static int g_LineNo;
+static int        g_InputLength;
+static int        g_LineNo;
 static MapVersion g_MapVersion;
 
 static int advanceCursor(int* pos, int steps) {
@@ -260,7 +260,7 @@ static bool check(TokenType got, TokenType expected) {
 }
 
 static double parseNumber(char* c, int* pos) {
-    char* cur = c + *pos;
+    char*       cur    = c + *pos;
     std::string number = "";
     while ( *cur == '-' || *cur >= '0' && *cur <= '9' || *cur == '.' ) {
         number += *cur;
@@ -271,7 +271,7 @@ static double parseNumber(char* c, int* pos) {
 }
 
 static MapVertex getVertex(char* c, int* pos) {
-    MapVertex v = {};
+    MapVertex           v = {};
     std::vector<double> values;
     for ( int i = 0; i < 3; i++ ) { // A face is defined by 3 vertices.
         advanceToNextNonWhitespace(c, pos);
@@ -287,7 +287,7 @@ static MapVertex getVertex(char* c, int* pos) {
 }
 
 static double getNumber(char* c, int* pos) {
-    char* cur = c + *pos;
+    char*       cur    = c + *pos;
     std::string number = "";
     while ( *cur == '-' || *cur >= '0' && *cur <= '9' || *cur == '.' || *cur == 'e' ) {
         number += *cur;
@@ -301,7 +301,7 @@ static std::string getTextureName(char* c, int* pos) {
     char* cur = c + *pos;
 
     std::string textureName = "";
-    char* end = cur;
+    char*       end         = cur;
     advanceToNextWhitespaceOrLinebreak(&end, pos);
     while ( cur != end ) {
         textureName += *cur;
@@ -482,9 +482,9 @@ Map getMap(char* mapData, size_t mapDataLength, MapVersion mapVersion) {
     Map map = {};
 
     g_InputLength = mapDataLength;
-    g_LineNo = 1; // Editors often start at line 1
-    g_MapVersion = mapVersion;
-    int pos = 0;
+    g_LineNo      = 1; // Editors often start at line 1
+    g_MapVersion  = mapVersion;
+    int pos       = 0;
     check(getToken(&mapData[ 0 ], &pos), LBRACE); // Map file must start with an entity!
     while ( getToken(&mapData[ 0 ], &pos) == LBRACE ) {
         pos++;
@@ -493,8 +493,6 @@ Map getMap(char* mapData, size_t mapDataLength, MapVersion mapVersion) {
 
     return map;
 }
-
-
 
 #endif
 

--- a/physics.cpp
+++ b/physics.cpp
@@ -11,36 +11,36 @@ void phys_Update(float dt) {
 
     // Acceleration due to gravity
     glm::vec3 gravity = glm::vec3(0.0f, 0.0f, -10.0f);
-    for (int i = 0; i < g_Bodies.size(); i++) {
+    for ( int i = 0; i < g_Bodies.size(); i++ ) {
         //g_Bodies[i]->m_LinearVelocity += glm::vec3(0.0f, 0.0f, -10.0f) * dt;
-        Body* body = g_Bodies[i];
-        float mass = 1.0f / body->m_InvMass;
+        Body*     body         = g_Bodies[ i ];
+        float     mass         = 1.0f / body->m_InvMass;
         glm::vec3 gravityForce = mass * gravity;
-        glm::vec3 impulse = gravityForce * dt;
+        glm::vec3 impulse      = gravityForce * dt;
         body->ApplyImpulseLinear(impulse);
     }
 
     // Check for collisions with other bodies
-    for (int i = 0; i < g_Bodies.size(); i++) {
-        for (int j = i + 1; j < g_Bodies.size(); j++) {
-            Body* bodyA = g_Bodies[i];
-            Body* bodyB = g_Bodies[j];
+    for ( int i = 0; i < g_Bodies.size(); i++ ) {
+        for ( int j = i + 1; j < g_Bodies.size(); j++ ) {
+            Body* bodyA = g_Bodies[ i ];
+            Body* bodyB = g_Bodies[ j ];
 
             // Bodies with infinite mass don't effect each other.
-            if (0.0f == bodyA->m_InvMass && 0.0f == bodyB->m_InvMass) {
+            if ( 0.0f == bodyA->m_InvMass && 0.0f == bodyB->m_InvMass ) {
                 continue;
             }
 
             Contact contact;
-            if (Intersect(bodyA, bodyB, contact)) {
+            if ( Intersect(bodyA, bodyB, contact) ) {
                 phys_ResolveContact(contact);
             }
         }
     }
 
     // Positional update based on velocity
-    for (int i = 0; i < g_Bodies.size(); i++) {
-        Body* body = g_Bodies[i];
+    for ( int i = 0; i < g_Bodies.size(); i++ ) {
+        Body* body = g_Bodies[ i ];
         body->m_Position += body->m_LinearVelocity * dt;
     }
 }
@@ -49,18 +49,18 @@ void phys_ResolveContact(Contact& contact) {
     Body* bodyA = contact.bodyA;
     Body* bodyB = contact.bodyB;
 
-    float invMassA = bodyA->m_InvMass;
-    float invMassB = bodyB->m_InvMass;
-    float elasticityA = bodyA->m_Elasticity;
-    float elasticityB = bodyB->m_Elasticity;
+    float invMassA           = bodyA->m_InvMass;
+    float invMassB           = bodyB->m_InvMass;
+    float elasticityA        = bodyA->m_Elasticity;
+    float elasticityB        = bodyB->m_Elasticity;
     float combinedElasticity = elasticityA * elasticityB;
 
-    glm::vec3 normal = contact.normal;
-    glm::vec3 vab = bodyA->m_LinearVelocity - bodyB->m_LinearVelocity;
-    float impulseJ = -(1.0f + combinedElasticity) * glm::dot(vab, normal) / (invMassA + invMassB);
+    glm::vec3 normal         = contact.normal;
+    glm::vec3 vab            = bodyA->m_LinearVelocity - bodyB->m_LinearVelocity;
+    float     impulseJ       = -(1.0f + combinedElasticity) * glm::dot(vab, normal) / (invMassA + invMassB);
     glm::vec3 vectorImpulseJ = impulseJ * normal;
 
-    glm::vec3 vectorImpulseJA =  1.0f * vectorImpulseJ;
+    glm::vec3 vectorImpulseJA = 1.0f * vectorImpulseJ;
     glm::vec3 vectorImpulseJB = -1.0f * vectorImpulseJ;
     bodyA->ApplyImpulseLinear(vectorImpulseJA);
     bodyB->ApplyImpulseLinear(vectorImpulseJB);

--- a/physics.h
+++ b/physics.h
@@ -1,16 +1,14 @@
 #ifndef _PHYSICS_H_
 #define _PHYSICS_H_
 
-#include <vector>
 #include "Body.h"
 #include "Intersections.h"
+#include <vector>
 
 static std::vector<Body*> g_Bodies;
 
 void phys_AddBody(Body* body);
 void phys_Update(float dt);
 void phys_ResolveContact(Contact& contact);
-
-
 
 #endif

--- a/platform.cpp
+++ b/platform.cpp
@@ -1,126 +1,125 @@
 #include "platform.h"
 
 #include <stdint.h>
-#include <string> 
+#include <string>
 
 #ifdef WIN32
 
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 
-std::string hkd_GetExePath(void)
-{
-	char out_buffer[256];
-	int  buffer_size = 256;
-	DWORD len = GetModuleFileNameA(NULL, out_buffer, buffer_size);
-	if (!len) {
-		DWORD error = GetLastError();
-		char errorMsgBuf[256];
-		FormatMessage(
-			FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-			NULL, error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-			errorMsgBuf, (sizeof(errorMsgBuf) / sizeof(char)), NULL);
+std::string hkd_GetExePath(void) {
+    char  out_buffer[ 256 ];
+    int   buffer_size = 256;
+    DWORD len         = GetModuleFileNameA(NULL, out_buffer, buffer_size);
+    if ( !len ) {
+        DWORD error = GetLastError();
+        char  errorMsgBuf[ 256 ];
+        FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                      NULL,
+                      error,
+                      MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+                      errorMsgBuf,
+                      (sizeof(errorMsgBuf) / sizeof(char)),
+                      NULL);
 
-		printf("%s\n", errorMsgBuf);
-	}
+        printf("%s\n", errorMsgBuf);
+    }
 
-	// strip actual name of the .exe
-	char* last = out_buffer + len;
-	while (*last != '\\') {
-		*last-- = '\0';
-	}
+    // strip actual name of the .exe
+    char* last = out_buffer + len;
+    while ( *last != '\\' ) {
+        *last-- = '\0';
+    }
 
-	return std::string(out_buffer);
+    return std::string(out_buffer);
 }
 
 #elif __APPLE__
 
 #include <mach-o/dyld.h>
 
-std::string hkd_GetExePath(void)
-{
-	char out_buffer[256];
-	uint32_t buffer_size = 256;
-	
-	int error = _NSGetExecutablePath(out_buffer, &buffer_size);
-	if (error) {
-		// TOOO: handle error
-	}
-	int len = strlen(out_buffer);
-	char* slash = out_buffer + len + 1;
-	while (len >= 0 && *slash != '/') { slash--; len--; }
-	out_buffer[len + 1] = '\0';
+std::string hkd_GetExePath(void) {
+    char     out_buffer[ 256 ];
+    uint32_t buffer_size = 256;
 
-	return std::string(out_buffer);
+    int error = _NSGetExecutablePath(out_buffer, &buffer_size);
+    if ( error ) {
+        // TOOO: handle error
+    }
+    int   len   = strlen(out_buffer);
+    char* slash = out_buffer + len + 1;
+    while ( len >= 0 && *slash != '/' ) {
+        slash--;
+        len--;
+    }
+    out_buffer[ len + 1 ] = '\0';
+
+    return std::string(out_buffer);
 }
 
 #elif __linux__
 
-#include <string.h>
 #include <SDL.h>
+#include <string.h>
 
-std::string hkd_GetExePath(void)
-{
-	char out_buffer[256];
-	int  buffer_size = 256;
-	char* basePath = SDL_GetBasePath();
+std::string hkd_GetExePath(void) {
+    char  out_buffer[ 256 ];
+    int   buffer_size = 256;
+    char* basePath    = SDL_GetBasePath();
 
-	return std::string(basePath);
+    return std::string(basePath);
 }
 #endif
 
-
 HKD_FileStatus hkd_read_file(char const* filename, HKD_File* out_File) {
-	FILE* file = 0;
-	file = fopen(filename, "rb");
-	if (file == 0) {
-		printf("Failed to open file: %s\n", filename);
-		return HKD_ERROR_READ_FILE;
-	}
-	fseek(file, 0L, SEEK_END);
-	out_File->size = ftell(file);
-	fseek(file, 0L, SEEK_SET);
-	out_File->data = (uint8_t*)malloc(out_File->size + 1);
-	fread(out_File->data, sizeof(uint8_t), out_File->size, file);
-	fclose(file);
+    FILE* file = 0;
+    file       = fopen(filename, "rb");
+    if ( file == 0 ) {
+        printf("Failed to open file: %s\n", filename);
+        return HKD_ERROR_READ_FILE;
+    }
+    fseek(file, 0L, SEEK_END);
+    out_File->size = ftell(file);
+    fseek(file, 0L, SEEK_SET);
+    out_File->data = (uint8_t*)malloc(out_File->size + 1);
+    fread(out_File->data, sizeof(uint8_t), out_File->size, file);
+    fclose(file);
 
-	out_File->data[out_File->size] = '\0';
+    out_File->data[ out_File->size ] = '\0';
 
-	return HKD_FILE_SUCCESS;
+    return HKD_FILE_SUCCESS;
 }
 
-HKD_FileStatus hkd_write_file(char const* filename, void* data, 
-							  size_t sizeElement, size_t numElements) {
-	FILE* pFile = 0;
-	pFile = fopen(filename, "wb");
-	if (pFile == 0) { // early out here.
-		printf("Failed to open file for writing: %s\n", filename);
-		return HKD_ERROR_WRITE_FILE;
-	}
+HKD_FileStatus hkd_write_file(char const* filename, void* data, size_t sizeElement, size_t numElements) {
+    FILE* pFile = 0;
+    pFile       = fopen(filename, "wb");
+    if ( pFile == 0 ) { // early out here.
+        printf("Failed to open file for writing: %s\n", filename);
+        return HKD_ERROR_WRITE_FILE;
+    }
 
-	HKD_FileStatus result;
-	size_t retFwriteOp = fwrite(data, sizeElement, numElements, pFile);
-	if ( retFwriteOp != numElements ) {
-		fprintf( stderr, "fread failed: %zu\n", retFwriteOp );
-		result = HKD_ERROR_WRITE_FILE;
-	}
-	else {
-		result = HKD_FILE_SUCCESS;
-	}
+    HKD_FileStatus result;
+    size_t         retFwriteOp = fwrite(data, sizeElement, numElements, pFile);
+    if ( retFwriteOp != numElements ) {
+        fprintf(stderr, "fread failed: %zu\n", retFwriteOp);
+        result = HKD_ERROR_WRITE_FILE;
+    } else {
+        result = HKD_FILE_SUCCESS;
+    }
 
-	fclose(pFile);
+    fclose(pFile);
 
-	return result;
+    return result;
 }
 
 HKD_FileStatus hkd_destroy_file(HKD_File* file) {
-	if (file->data != NULL) {
-		free(file->data);
-		file->size = 0;
+    if ( file->data != NULL ) {
+        free(file->data);
+        file->size = 0;
 
-		return HKD_FILE_SUCCESS;
-	}
+        return HKD_FILE_SUCCESS;
+    }
 
-	return HKD_ERROR_NO_FILE;
+    return HKD_ERROR_NO_FILE;
 }
-

--- a/platform.h
+++ b/platform.h
@@ -5,25 +5,21 @@
 
 #include <string>
 
-enum HKD_FileStatus
-{
-	HKD_FILE_SUCCESS,
-	HKD_ERROR_READ_FILE,
-	HKD_ERROR_WRITE_FILE,
-	HKD_ERROR_NO_FILE
+enum HKD_FileStatus {
+    HKD_FILE_SUCCESS,
+    HKD_ERROR_READ_FILE,
+    HKD_ERROR_WRITE_FILE,
+    HKD_ERROR_NO_FILE
 };
 
-struct HKD_File
-{
-	uint8_t* data;
-	uint32_t size;
+struct HKD_File {
+    uint8_t* data;
+    uint32_t size;
 };
 
-std::string			hkd_GetExePath(void);
-HKD_FileStatus      hkd_read_file(char const* filename, HKD_File* out_File);
-HKD_FileStatus		hkd_write_file(char const* filename, void* data,
-							   size_t sizeElment, size_t numElements);
-HKD_FileStatus      hkd_destroy_file(HKD_File* file);
+std::string    hkd_GetExePath(void);
+HKD_FileStatus hkd_read_file(char const* filename, HKD_File* out_File);
+HKD_FileStatus hkd_write_file(char const* filename, void* data, size_t sizeElment, size_t numElements);
+HKD_FileStatus hkd_destroy_file(HKD_File* file);
 
 #endif
-

--- a/polysoup.cpp
+++ b/polysoup.cpp
@@ -2,40 +2,38 @@
 //#define MAP_PARSER_IMPLEMENTATION
 #include "map_parser.h"
 
-
-#include <string>
-#include <iostream>
-#include <fstream>
-#include <ostream>
-#include <sstream>
-#include <vector>
-#include <unordered_map>
-#include <set>
-#include <stack>
 #include <algorithm>
+#include <fstream>
+#include <iostream>
+#include <ostream>
+#include <set>
+#include <sstream>
+#include <stack>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdint.h>
 #include <string.h>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
-#include <glm/glm.hpp>
 #include <glm/ext.hpp>
+#include <glm/glm.hpp>
 
 #include "polysoup.h"
 
 #include "image.h"
 #include "platform.h"
 
-#define PS_FLOAT_EPSILON    (0.0001)
+#define PS_FLOAT_EPSILON (0.0001)
 
 extern std::string g_GameDir;
 
-std::string loadTextFile(std::string file)
-{
-    std::ifstream iFileStream;
+std::string loadTextFile(std::string file) {
+    std::ifstream     iFileStream;
     std::stringstream ss;
     iFileStream.open(file, std::ifstream::in);
-    if (iFileStream.fail()) {
+    if ( iFileStream.fail() ) {
         fprintf(stderr, "Unable to open file: %s!\nExiting...", file.c_str());
         exit(-1);
     }
@@ -48,17 +46,16 @@ std::string loadTextFile(std::string file)
 
 // @DEPRECATED: Writes only the polys out to disk without a
 // header. Use writePolySoupBinary (see below) instead!
-void writePolys(std::string fileName, std::vector<MapPolygon> polys)
-{
+void writePolys(std::string fileName, std::vector<MapPolygon> polys) {
     std::ofstream oFileStream;
     oFileStream.open(fileName, std::ios::binary | std::ios::out);
 
     uint32_t numPolys = polys.size();
     oFileStream.write((char*)&numPolys, sizeof(uint32_t));
 
-    for (auto p = polys.begin(); p != polys.end(); p++) {
-        for (auto v = p->vertices.begin(); v != p->vertices.end(); v++) {
-            oFileStream.write((char*) & (v->pos), sizeof(glm::f64vec3));
+    for ( auto p = polys.begin(); p != polys.end(); p++ ) {
+        for ( auto v = p->vertices.begin(); v != p->vertices.end(); v++ ) {
+            oFileStream.write((char*)&(v->pos), sizeof(glm::f64vec3));
         }
     }
 
@@ -77,13 +74,12 @@ void writePolySoupBinary(std::string fileName, const std::vector<MapPolygon>& po
 
     uint64_t totalPolySize = numPolys * polySize;
 
-    size_t totalFileSize = sizeof(PolySoupDataHeader) + (size_t)totalPolySize;
-    uint8_t* data = (uint8_t*)malloc(totalFileSize);
-    memcpy( data, &header, sizeof(PolySoupDataHeader) );
-    memcpy( data + sizeof(PolySoupDataHeader), polys.data(), (size_t)totalPolySize );
+    size_t   totalFileSize = sizeof(PolySoupDataHeader) + (size_t)totalPolySize;
+    uint8_t* data          = (uint8_t*)malloc(totalFileSize);
+    memcpy(data, &header, sizeof(PolySoupDataHeader));
+    memcpy(data + sizeof(PolySoupDataHeader), polys.data(), (size_t)totalPolySize);
 
-    if ( hkd_write_file(fileName.c_str(), data, totalFileSize, 1)
-         != HKD_FILE_SUCCESS ) {
+    if ( hkd_write_file(fileName.c_str(), data, totalFileSize, 1) != HKD_FILE_SUCCESS ) {
 
         printf("Failed to write Polysoup binary data to file!\n");
     }
@@ -91,150 +87,138 @@ void writePolySoupBinary(std::string fileName, const std::vector<MapPolygon>& po
     free(data);
 }
 
-void writePolysOBJ(std::string fileName, std::vector<MapPolygon> polys)
-{
+void writePolysOBJ(std::string fileName, std::vector<MapPolygon> polys) {
     std::stringstream faces;
-    std::ofstream oFileStream;
+    std::ofstream     oFileStream;
     oFileStream.open(fileName, std::ios::out);
-    
+
     oFileStream << "o Quake-map" << std::endl;
 
     size_t count = 1;
-    for (auto p = polys.begin(); p != polys.end(); p++) {
+    for ( auto p = polys.begin(); p != polys.end(); p++ ) {
         faces << "f";
-        for (auto v = p->vertices.begin(); v != p->vertices.end(); v++) {
-            oFileStream << "v " << std::to_string(v->pos.x) << " " << std::to_string(v->pos.z) << " " << std::to_string(-v->pos.y) << std::endl;
-            faces << " " << count; count++;
+        for ( auto v = p->vertices.begin(); v != p->vertices.end(); v++ ) {
+            oFileStream << "v " << std::to_string(v->pos.x) << " " << std::to_string(v->pos.z) << " "
+                        << std::to_string(-v->pos.y) << std::endl;
+            faces << " " << count;
+            count++;
         }
         faces << std::endl;
     }
 
     oFileStream << faces.rdbuf();
     oFileStream.close();
-    
 }
 
-MapPlane createPlane(glm::f64vec3 p0, glm::f64vec3 p1, glm::f64vec3 p2)
-{
+MapPlane createPlane(glm::f64vec3 p0, glm::f64vec3 p1, glm::f64vec3 p2) {
     glm::f64vec3 v0 = p2 - p0;
     glm::f64vec3 v1 = p1 - p0;
-    glm::f64vec3 n = glm::normalize(glm::cross(v0, v1));
-    double d = -glm::dot(n, p0);
+    glm::f64vec3 n  = glm::normalize(glm::cross(v0, v1));
+    double       d  = -glm::dot(n, p0);
 
     return { n, p0, d };
 }
 
-glm::f64vec3 convertVertexToVec3(MapVertex v)
-{
+glm::f64vec3 convertVertexToVec3(MapVertex v) {
     return glm::f64vec3(v.x, v.y, v.z);
 }
 
-MapPlane convertFaceToPlane(Face face)
-{
-    glm::f64vec3 p0 = convertVertexToVec3(face.vertices[0]);
-    glm::f64vec3 p1 = convertVertexToVec3(face.vertices[1]);
-    glm::f64vec3 p2 = convertVertexToVec3(face.vertices[2]);
+MapPlane convertFaceToPlane(Face face) {
+    glm::f64vec3 p0 = convertVertexToVec3(face.vertices[ 0 ]);
+    glm::f64vec3 p1 = convertVertexToVec3(face.vertices[ 1 ]);
+    glm::f64vec3 p2 = convertVertexToVec3(face.vertices[ 2 ]);
     return createPlane(p0, p1, p2);
 }
 
-bool intersectThreePlanes(MapPlane p0, MapPlane p1, MapPlane p2, glm::f64vec3* intersectionPoint)
-{   
+bool intersectThreePlanes(MapPlane p0, MapPlane p1, MapPlane p2, glm::f64vec3* intersectionPoint) {
     glm::f64vec3 n0xn1 = glm::cross(p0.n, p1.n);
-    double det = glm::dot(n0xn1, p2.n);
+    double       det   = glm::dot(n0xn1, p2.n);
 
-    if (fabs(det) < PS_FLOAT_EPSILON) // Early out if planes do not intersect at single point
+    if ( fabs(det) < PS_FLOAT_EPSILON ) // Early out if planes do not intersect at single point
         return false;
 
-    *intersectionPoint = (
-        -p0.d * (glm::cross(p1.n, p2.n))
-        -p1.d * (glm::cross(p2.n, p0.n))
-        -p2.d * (glm::cross(p0.n, p1.n))
-        ) / det;
+    *intersectionPoint
+        = (-p0.d * (glm::cross(p1.n, p2.n))-p1.d * (glm::cross(p2.n, p0.n))-p2.d * (glm::cross(p0.n, p1.n))) / det;
 
     return true;
 }
 
 bool vec3IsEqual(const glm::f64vec3& lhs, const glm::f64vec3& rhs) {
-    return ( glm::abs(lhs.x - rhs.x) < PS_FLOAT_EPSILON 
-        && glm::abs(lhs.y - rhs.y) < PS_FLOAT_EPSILON
-        && glm::abs(lhs.z - rhs.z) < PS_FLOAT_EPSILON );
+    return (glm::abs(lhs.x - rhs.x) < PS_FLOAT_EPSILON && glm::abs(lhs.y - rhs.y) < PS_FLOAT_EPSILON
+            && glm::abs(lhs.z - rhs.z) < PS_FLOAT_EPSILON);
 }
 
-void insertVertexToPolygon(QuakeMapVertex v, MapPolygon* p)
-{
+void insertVertexToPolygon(QuakeMapVertex v, MapPolygon* p) {
     auto v0 = p->vertices.begin();
     if ( v0 == p->vertices.end() ) {
-        p->vertices.push_back( v ); 
+        p->vertices.push_back(v);
         return;
     }
 
-    for (; v0 != p->vertices.end(); v0++) {
+    for ( ; v0 != p->vertices.end(); v0++ ) {
         // TODO: Is this check actually needed??
         // TODO: Also check for UV? (Probably not because
         //       it is purely geometry related).
-        if ( vec3IsEqual(v.pos, v0->pos) ) { 
+        if ( vec3IsEqual(v.pos, v0->pos) ) {
             return;
         }
     }
-    
-    p->vertices.push_back( v ); 
+
+    p->vertices.push_back(v);
 }
 
-bool isPointInsideBrush(Brush brush, glm::f64vec3 intersectionPoint)
-{
-    for (int i = 0; i < brush.faces.size(); i++) {
-        Face face = brush.faces[i];
-        MapPlane plane = convertFaceToPlane(face);
-        glm::f64vec3 a = glm::normalize(intersectionPoint - plane.p0);
-        double dotProd = glm::dot(plane.n, a);
-        if (glm::dot(plane.n, intersectionPoint) + plane.d > PS_FLOAT_EPSILON) // FIXME: HOW DO WE GET IT NUMERICALLY GOOD ENOUGH??
+bool isPointInsideBrush(Brush brush, glm::f64vec3 intersectionPoint) {
+    for ( int i = 0; i < brush.faces.size(); i++ ) {
+        Face         face    = brush.faces[ i ];
+        MapPlane     plane   = convertFaceToPlane(face);
+        glm::f64vec3 a       = glm::normalize(intersectionPoint - plane.p0);
+        double       dotProd = glm::dot(plane.n, a);
+        if ( glm::dot(plane.n, intersectionPoint) + plane.d
+             > PS_FLOAT_EPSILON ) // FIXME: HOW DO WE GET IT NUMERICALLY GOOD ENOUGH??
             return false;
     }
 
     return true;
 }
 
-std::vector<MapPolygon> createPolysoup(const Brush& brush)
-{
-    std::vector<MapPolygon> polys; 
+std::vector<MapPolygon> createPolysoup(const Brush& brush) {
+    std::vector<MapPolygon> polys;
 
     int faceCount = brush.faces.size();
-    for (int i = 0; i <  faceCount; i++) {
-        Face face_i = brush.faces[i];
-        glm::vec3 axisU = glm::vec3( face_i.tx1, face_i.ty1, face_i.tz1 );
-        glm::vec3 axisV = glm::vec3( face_i.tx2, face_i.ty2, face_i.tz2 );
-        MapPlane p0 = convertFaceToPlane(face_i);
-        MapPolygon poly = {};
-        poly.textureName = face_i.textureName;
-        float texWidth = 1.0f;
-        float texHeight = 1.0f;
+    for ( int i = 0; i < faceCount; i++ ) {
+        Face       face_i = brush.faces[ i ];
+        glm::vec3  axisU  = glm::vec3(face_i.tx1, face_i.ty1, face_i.tz1);
+        glm::vec3  axisV  = glm::vec3(face_i.tx2, face_i.ty2, face_i.tz2);
+        MapPlane   p0     = convertFaceToPlane(face_i);
+        MapPolygon poly   = {};
+        poly.textureName  = face_i.textureName;
+        float texWidth    = 1.0f;
+        float texHeight   = 1.0f;
         // FIX: (Michael): Before Michael goes an implements a new
         // feature he has to implement a decent virtual file-system!
         // This is a boring job but it has to be done!!!
-        CImage texImage( "textures/" + poly.textureName + ".tga" );
+        CImage texImage("textures/" + poly.textureName + ".tga");
         if ( texImage.Valid() ) {
-            texWidth = (float)texImage.Width();
+            texWidth  = (float)texImage.Width();
             texHeight = (float)texImage.Height();
         }
         poly.normal = p0.n;
-        for (int j = 0; j < faceCount; j++) {
-            MapPlane p1 = convertFaceToPlane(brush.faces[j]);
-            for (int k = 0; k < faceCount; k++) {
+        for ( int j = 0; j < faceCount; j++ ) {
+            MapPlane p1 = convertFaceToPlane(brush.faces[ j ]);
+            for ( int k = 0; k < faceCount; k++ ) {
                 glm::f64vec3 intersectionPoint;
-                MapPlane p2 = convertFaceToPlane(brush.faces[k]);
-                if ( (i != j) && (j != k) && (i != k) ) { 
-                    if (intersectThreePlanes(p0, p1, p2, &intersectionPoint)) {
-                        if (isPointInsideBrush(brush, intersectionPoint)) {
+                MapPlane     p2 = convertFaceToPlane(brush.faces[ k ]);
+                if ( (i != j) && (j != k) && (i != k) ) {
+                    if ( intersectThreePlanes(p0, p1, p2, &intersectionPoint) ) {
+                        if ( isPointInsideBrush(brush, intersectionPoint) ) {
                             // TODO: Calculate texture coordinates
-                            glm::vec2 uv = {
-                                glm::dot( (glm::vec3)intersectionPoint, axisU ),
-                                glm::dot( (glm::vec3)intersectionPoint, axisV )
-                            };
+                            glm::vec2 uv = { glm::dot((glm::vec3)intersectionPoint, axisU),
+                                             glm::dot((glm::vec3)intersectionPoint, axisV) };
                             uv.x /= face_i.xScale;
                             uv.y /= face_i.yScale;
                             uv.x += face_i.tOffset1;
                             uv.y += face_i.tOffset2;
-                            uv.x /= texWidth; 
+                            uv.x /= texWidth;
                             uv.y /= texHeight;
                             //uv.y = 1.0f - uv.y;
                             QuakeMapVertex v = { intersectionPoint, uv };
@@ -244,7 +228,7 @@ std::vector<MapPolygon> createPolysoup(const Brush& brush)
                 }
             }
         }
-        if (poly.vertices.size() > 0) {
+        if ( poly.vertices.size() > 0 ) {
             polys.push_back(poly);
         }
 
@@ -258,75 +242,70 @@ std::vector<MapPolygon> createPolysoup(const Brush& brush)
 }
 
 static bool hasClassname(const Entity& e, std::string classname) {
-    for (int i = 0; i < e.properties.size(); i++) {
+    for ( int i = 0; i < e.properties.size(); i++ ) {
         const Property& p = e.properties[ i ];
         if ( p.value == classname ) {
             return true;
         }
     }
-    
+
     return false;
 }
 
-std::vector<MapPolygon> createPolysoup(Map map, SoupFlags soupFlags)
-{
+std::vector<MapPolygon> createPolysoup(Map map, SoupFlags soupFlags) {
     std::vector<MapPolygon> polys;
-    for (auto e = map.entities.begin(); e != map.entities.end(); e++) {
-       
+    for ( auto e = map.entities.begin(); e != map.entities.end(); e++ ) {
+
         // Check if we also want the brush entities included or not (default = not).
         if ( !hasClassname(*e, "worldspawn") && !hasClassname(*e, "func_group")
-            && (soupFlags == SOUP_GET_WORLDSPAWN_ONLY) ) {
+             && (soupFlags == SOUP_GET_WORLDSPAWN_ONLY) ) {
             continue;
         }
 
-        for (auto b = e->brushes.begin(); b != e->brushes.end(); b++) {
-            std::vector<MapPolygon> brushPolys = createPolysoup( *b ); 
+        for ( auto b = e->brushes.begin(); b != e->brushes.end(); b++ ) {
+            std::vector<MapPolygon> brushPolys = createPolysoup(*b);
             // NOTE: (Michael): I cannot wait to get rid off this STL nonsense...
-            polys.insert( polys.end(), brushPolys.begin(), brushPolys.end() );
+            polys.insert(polys.end(), brushPolys.begin(), brushPolys.end());
         }
     }
 
     return polys;
 }
 
-bool isAngleLegal(glm::f64vec3 center, glm::f64vec3 v0, glm::f64vec3 v1)
-{
-    MapPlane polyPlane = createPlane(center, v0, v1);
-    glm::f64vec3 b = glm::normalize(v1 - center);
-    MapPlane p = createPlane(center, v0, center + polyPlane.n);
-    if (glm::dot(p.n, b) < -0.00001) {
+bool isAngleLegal(glm::f64vec3 center, glm::f64vec3 v0, glm::f64vec3 v1) {
+    MapPlane     polyPlane = createPlane(center, v0, v1);
+    glm::f64vec3 b         = glm::normalize(v1 - center);
+    MapPlane     p         = createPlane(center, v0, center + polyPlane.n);
+    if ( glm::dot(p.n, b) < -0.00001 ) {
         return false;
     }
 
     return true;
 }
 
-double getAngle(glm::f64vec3 center, glm::f64vec3 v0, glm::f64vec3 v1)
-{
+double getAngle(glm::f64vec3 center, glm::f64vec3 v0, glm::f64vec3 v1) {
     glm::f64vec3 a = glm::normalize(v0 - center);
     glm::f64vec3 b = glm::normalize(v1 - center);
 
     return glm::dot(a, b);
 }
 
-MapPolygon sortVerticesCCW(MapPolygon poly)
-{
+MapPolygon sortVerticesCCW(MapPolygon poly) {
     MapPolygon result;
-    size_t vertCount = poly.vertices.size();
-    
-    if (vertCount < 3)
-        return poly; // Actually not a valid polygon
+    size_t     vertCount = poly.vertices.size();
+
+    if ( vertCount < 3 ) return poly; // Actually not a valid polygon
 
     // Center of poly
     glm::f64vec3 center(0.0f);
-    for (auto v = poly.vertices.begin(); v != poly.vertices.end(); v++) {
+    for ( auto v = poly.vertices.begin(); v != poly.vertices.end(); v++ ) {
         center += v->pos;
     }
     center /= vertCount;
 
     size_t closestVertexID = 0;
-    for (size_t i = 0; i < vertCount-1; i++) {
-        glm::f64vec3 v0pos = poly.vertices[i].pos; // Find next vertex to v0 with smallest angle
+    for ( size_t i = 0; i < vertCount - 1; i++ ) {
+        glm::f64vec3 v0pos = poly.vertices[ i ].pos; // Find next vertex to v0 with smallest angle
 
         // Plane definition:
         // glm::f64vec3 v0 = p2 - p0;
@@ -334,26 +313,26 @@ MapPolygon sortVerticesCCW(MapPolygon poly)
         // glm::f64vec3 n = glm::normalize(glm::cross(v0, v1));
         MapPlane plane = createPlane(center, v0pos, center + poly.normal);
 
-        int smallesAngleIndex = 0;
-        double smallestAngle = -1.0;
-        for (size_t j = i+1; j < vertCount; j++) {
-            glm::f64vec3 test = glm::normalize(poly.vertices[j].pos - center);
-            if (glm::dot(plane.n, test) < -PS_FLOAT_EPSILON) { // check if point is legal
-                double angle = getAngle(center, v0pos, poly.vertices[j].pos);
-                if (angle > smallestAngle) {
-                    smallestAngle = angle;
+        int    smallesAngleIndex = 0;
+        double smallestAngle     = -1.0;
+        for ( size_t j = i + 1; j < vertCount; j++ ) {
+            glm::f64vec3 test = glm::normalize(poly.vertices[ j ].pos - center);
+            if ( glm::dot(plane.n, test) < -PS_FLOAT_EPSILON ) { // check if point is legal
+                double angle = getAngle(center, v0pos, poly.vertices[ j ].pos);
+                if ( angle > smallestAngle ) {
+                    smallestAngle     = angle;
                     smallesAngleIndex = j;
                 }
             }
-        }   
-        std::swap(poly.vertices[i+1], poly.vertices[smallesAngleIndex]);
+        }
+        std::swap(poly.vertices[ i + 1 ], poly.vertices[ smallesAngleIndex ]);
     }
 
     // Fix winding
-    glm::f64vec3 a = poly.vertices[0].pos - center;
-    glm::f64vec3 b = poly.vertices[1].pos - center;
+    glm::f64vec3 a      = poly.vertices[ 0 ].pos - center;
+    glm::f64vec3 b      = poly.vertices[ 1 ].pos - center;
     glm::f64vec3 normal = glm::normalize(glm::cross(a, b));
-    if (glm::dot(normal, poly.normal) < PS_FLOAT_EPSILON) {
+    if ( glm::dot(normal, poly.normal) < PS_FLOAT_EPSILON ) {
         std::reverse(poly.vertices.begin(), poly.vertices.end());
         poly.normal = normal;
     }
@@ -379,22 +358,21 @@ MapPolygon sortVerticesCCW(MapPolygon poly)
 * 
 * TODO: Fix this with indexed data.
 */
-std::vector<MapPolygon> triangulate(std::vector<MapPolygon> polys)
-{
-    std::vector<MapPolygon> tris = { };
+std::vector<MapPolygon> triangulate(std::vector<MapPolygon> polys) {
+    std::vector<MapPolygon> tris = {};
 
-    for (auto p = polys.begin(); p != polys.end(); p++) {
-        MapPolygon sortedPoly = sortVerticesCCW(*p);
-        size_t vertCount = sortedPoly.vertices.size();      
-        QuakeMapVertex provokingVert = sortedPoly.vertices[0];
-        for (size_t i = 2; i < vertCount; i++) {
-            MapPolygon poly = { };
+    for ( auto p = polys.begin(); p != polys.end(); p++ ) {
+        MapPolygon     sortedPoly    = sortVerticesCCW(*p);
+        size_t         vertCount     = sortedPoly.vertices.size();
+        QuakeMapVertex provokingVert = sortedPoly.vertices[ 0 ];
+        for ( size_t i = 2; i < vertCount; i++ ) {
+            MapPolygon poly = {};
             poly.vertices.push_back(provokingVert);
-            poly.vertices.push_back(sortedPoly.vertices[i - 1]);
-            poly.vertices.push_back(sortedPoly.vertices[i]);
+            poly.vertices.push_back(sortedPoly.vertices[ i - 1 ]);
+            poly.vertices.push_back(sortedPoly.vertices[ i ]);
             poly.textureName = p->textureName;
-            tris.push_back(poly); 
-        }       
+            tris.push_back(poly);
+        }
     }
 
     return tris;

--- a/polysoup.h
+++ b/polysoup.h
@@ -1,15 +1,15 @@
 #ifndef _POLYSOUP_H_
 #define _POLYSOUP_H_
 
-#include <vector>
-#include <string>
-#include <glm/glm.hpp>
 #include <glm/ext.hpp>
+#include <glm/glm.hpp>
+#include <string>
+#include <vector>
 
 #include "map_parser.h"
 
-static const uint8_t POLY_SOUP_MAGIC[4]   = { 'P', 'L', 'Y', '\0' };
-static const uint8_t POLY_SOUP_VERSION[4] = { '0', '0', '1', '\0' };
+static const uint8_t POLY_SOUP_MAGIC[ 4 ]   = { 'P', 'L', 'Y', '\0' };
+static const uint8_t POLY_SOUP_VERSION[ 4 ] = { '0', '0', '1', '\0' };
 
 enum SoupFlags {
     SOUP_GET_ALL,
@@ -17,40 +17,38 @@ enum SoupFlags {
 };
 
 struct QuakeMapVertex {
-    glm::f64vec3  pos;
-    glm::vec2     uv;
+    glm::f64vec3 pos;
+    glm::vec2    uv;
 };
 
-struct MapPolygon
-{
+struct MapPolygon {
     std::vector<QuakeMapVertex> vertices;
     glm::f64vec3                normal;
     // NOTE: (Michael): A single, solid color would be good for testing
-    // the lightmapper. Thus, define a few solid color textures 
+    // the lightmapper. Thus, define a few solid color textures
     // to use in TrenchBroom.
-    std::string                 textureName;  // located in /game/textures/<*.png>
-    uint64_t                    surfaceFlags; // eg. transparency, emissiveness, ...
-    uint64_t                    contentFlags; // eg. water, slime, lava, ...
+    std::string textureName;  // located in /game/textures/<*.png>
+    uint64_t    surfaceFlags; // eg. transparency, emissiveness, ...
+    uint64_t    contentFlags; // eg. water, slime, lava, ...
 };
 
-struct MapPlane
-{
+struct MapPlane {
     glm::f64vec3 n;
     glm::f64vec3 p0;
-    double d;       // = n dot p0. Just for convenience.
+    double       d; // = n dot p0. Just for convenience.
 };
 
 struct PolySoupDataHeader {
-    uint8_t     magic[4];   // must be PLYS
-    uint8_t     version[4];
-    uint64_t    numPolys;   // num of MapPolygons
-    uint64_t    polySize; // sizeof(MapPolygon)
+    uint8_t  magic[ 4 ]; // must be PLYS
+    uint8_t  version[ 4 ];
+    uint64_t numPolys; // num of MapPolygons
+    uint64_t polySize; // sizeof(MapPolygon)
 };
 
-#pragma pack(push,1)
+#pragma pack(push, 1)
 struct PolySoupData {
-    PolySoupDataHeader  header;
-    MapPolygon*         polys;
+    PolySoupDataHeader header;
+    MapPolygon*        polys;
 };
 #pragma pack(pop)
 
@@ -65,12 +63,11 @@ bool                    intersectThreePlanes(MapPlane p0, MapPlane p1, MapPlane 
 bool                    vec3IsEqual(const glm::f64vec3& lhs, const glm::f64vec3& rhs);
 void                    insertVertexToPolygon(glm::f64vec3 v, MapPolygon* p);
 bool                    isPointInsideBrush(Brush brush, glm::f64vec3 intersectionPoint);
-std::vector<MapPolygon> createPolysoup(Map map, SoupFlags soupFlags = SOUP_GET_WORLDSPAWN_ONLY); 
+std::vector<MapPolygon> createPolysoup(Map map, SoupFlags soupFlags = SOUP_GET_WORLDSPAWN_ONLY);
 std::vector<MapPolygon> createPolysoup(const Brush& brush);
 bool                    isAngleLegal(glm::f64vec3 center, glm::f64vec3 v0, glm::f64vec3 v1);
 double                  getAngle(glm::f64vec3 center, glm::f64vec3 v0, glm::f64vec3 v1);
 MapPolygon              sortVerticesCCW(MapPolygon poly);
 std::vector<MapPolygon> triangulate(std::vector<MapPolygon> polys);
-
 
 #endif

--- a/r_common.cpp
+++ b/r_common.cpp
@@ -1,254 +1,249 @@
-#include "r_common.h" 
+#include "r_common.h"
 
 #include <math.h>
 
-
-#include "r_model.h"
 #include "collision.h"
+#include "r_model.h"
 
 #define GLM_FORCE_RADIANS
-#include "dependencies/glm/glm.hpp"
 #include "dependencies/glm/ext.hpp"
+#include "dependencies/glm/glm.hpp"
 #include "dependencies/glm/gtx/quaternion.hpp"
 
-void RotateTri(Tri* tri, glm::vec3 axis, float angle)
-{
-	glm::quat q = glm::angleAxis(glm::radians(angle), glm::normalize(axis));
-	tri->a.pos = glm::rotate(q, tri->a.pos);
-	tri->b.pos = glm::rotate(q, tri->b.pos);
-	tri->c.pos = glm::rotate(q, tri->c.pos);
-	tri->a.normal = glm::rotate(q, tri->a.normal);
-	tri->b.normal = glm::rotate(q, tri->b.normal);
-	tri->c.normal = glm::rotate(q, tri->c.normal);
+void RotateTri(Tri* tri, glm::vec3 axis, float angle) {
+    glm::quat q   = glm::angleAxis(glm::radians(angle), glm::normalize(axis));
+    tri->a.pos    = glm::rotate(q, tri->a.pos);
+    tri->b.pos    = glm::rotate(q, tri->b.pos);
+    tri->c.pos    = glm::rotate(q, tri->c.pos);
+    tri->a.normal = glm::rotate(q, tri->a.normal);
+    tri->b.normal = glm::rotate(q, tri->b.normal);
+    tri->c.normal = glm::rotate(q, tri->c.normal);
 }
 
-void TranslateTri(Tri* tri, glm::vec3 t)
-{
-	tri->a.pos += t;
-	tri->b.pos += t;
-	tri->c.pos += t;
+void TranslateTri(Tri* tri, glm::vec3 t) {
+    tri->a.pos += t;
+    tri->b.pos += t;
+    tri->c.pos += t;
 }
 
-void TransformTri(Tri* tri, glm::mat4 modelMatrix)
-{
-	tri->a.pos = modelMatrix * glm::vec4(tri->a.pos, 1.0f);
-	tri->b.pos = modelMatrix * glm::vec4(tri->b.pos, 1.0f);
-	tri->c.pos = modelMatrix * glm::vec4(tri->c.pos, 1.0f);
+void TransformTri(Tri* tri, glm::mat4 modelMatrix) {
+    tri->a.pos = modelMatrix * glm::vec4(tri->a.pos, 1.0f);
+    tri->b.pos = modelMatrix * glm::vec4(tri->b.pos, 1.0f);
+    tri->c.pos = modelMatrix * glm::vec4(tri->c.pos, 1.0f);
 }
 
-void SetTriColor(Tri* tri, glm::vec4 color)
-{
-	tri->a.color = color;
-	tri->b.color = color;
-	tri->c.color = color;
+void SetTriColor(Tri* tri, glm::vec4 color) {
+    tri->a.color = color;
+    tri->b.color = color;
+    tri->c.color = color;
 }
 
-void SubdivTri(Tri* tri, Tri out_tris[])
-{	
-	glm::vec3 A = tri->a.pos;
-	glm::vec3 B = tri->b.pos;
-	glm::vec3 C = tri->c.pos;
+void SubdivTri(Tri* tri, Tri out_tris[]) {
+    glm::vec3 A = tri->a.pos;
+    glm::vec3 B = tri->b.pos;
+    glm::vec3 C = tri->c.pos;
 
-	// Vectors from vert to vert.
+    // Vectors from vert to vert.
 
-	glm::vec3 AB = B - A;
-	glm::vec3 BC = C - B;
-	glm::vec3 CA = A - C;
+    glm::vec3 AB = B - A;
+    glm::vec3 BC = C - B;
+    glm::vec3 CA = A - C;
 
-	// Midpoints between the points on half distance
+    // Midpoints between the points on half distance
 
-	glm::vec3 mAB = A + 0.5f * AB;
-	glm::vec3 mBC = B + 0.5f * BC;
-	glm::vec3 mCA = C + 0.5f * CA;
+    glm::vec3 mAB = A + 0.5f * AB;
+    glm::vec3 mBC = B + 0.5f * BC;
+    glm::vec3 mCA = C + 0.5f * CA;
 
-	// Colors between points
+    // Colors between points
 
-	glm::vec4 cAB = 0.5f * tri->a.color + 0.5f * tri->b.color;
-	glm::vec4 cBC = 0.5f * tri->b.color + 0.5f * tri->c.color;
-	glm::vec4 cCA = 0.5f * tri->c.color + 0.5f * tri->a.color;
+    glm::vec4 cAB = 0.5f * tri->a.color + 0.5f * tri->b.color;
+    glm::vec4 cBC = 0.5f * tri->b.color + 0.5f * tri->c.color;
+    glm::vec4 cCA = 0.5f * tri->c.color + 0.5f * tri->a.color;
 
-	// New tris
+    // New tris
 
-	Tri t1 = { .vertices = { {.pos = A}, {.pos = mAB}, {.pos = mCA} } };
-	Tri t2 = { .vertices = { {.pos = mAB}, {.pos = B}, {.pos = mBC} } };
-	Tri t3 = { .vertices = { {.pos = mBC}, {.pos = C}, {.pos = mCA} } };
-	Tri t4 = { .vertices = { {.pos = mCA}, {.pos = mAB}, {.pos = mBC} } };
-	t1.a.color = tri->a.color;
-	t1.b.color = cAB;
-	t1.c.color = cCA;
-	t2.a.color = cAB;
-	t2.b.color = tri->b.color;
-	t2.c.color = cBC;
-	t3.a.color = cBC;
-	t3.b.color = tri->c.color;
-	t3.c.color = cCA;
-	t4.a.color = cCA;
-	t4.b.color = cAB;
-	t4.c.color = cBC;
+    Tri t1     = { .vertices = { { .pos = A }, { .pos = mAB }, { .pos = mCA } } };
+    Tri t2     = { .vertices = { { .pos = mAB }, { .pos = B }, { .pos = mBC } } };
+    Tri t3     = { .vertices = { { .pos = mBC }, { .pos = C }, { .pos = mCA } } };
+    Tri t4     = { .vertices = { { .pos = mCA }, { .pos = mAB }, { .pos = mBC } } };
+    t1.a.color = tri->a.color;
+    t1.b.color = cAB;
+    t1.c.color = cCA;
+    t2.a.color = cAB;
+    t2.b.color = tri->b.color;
+    t2.c.color = cBC;
+    t3.a.color = cBC;
+    t3.b.color = tri->c.color;
+    t3.c.color = cCA;
+    t4.a.color = cCA;
+    t4.b.color = cAB;
+    t4.c.color = cBC;
 
-	out_tris[0] = t1;
-	out_tris[1] = t2;
-	out_tris[2] = t3;
-	out_tris[3] = t4;
+    out_tris[ 0 ] = t1;
+    out_tris[ 1 ] = t2;
+    out_tris[ 2 ] = t3;
+    out_tris[ 3 ] = t4;
 }
 
-void SubdivTri(Tri* tri, Tri out_tris[], uint32_t numIterations)
-{
-	// each iteration makes one tri to four tris -> 4 tris -> 16 tris and so on.
-	// so each iteration will multiply the current tricount by 4.
+void SubdivTri(Tri* tri, Tri out_tris[], uint32_t numIterations) {
+    // each iteration makes one tri to four tris -> 4 tris -> 16 tris and so on.
+    // so each iteration will multiply the current tricount by 4.
 
-	uint32_t maxTris = pow(4, numIterations);
-	
-	//SubdivTri(tri, out_tris);	
+    uint32_t maxTris = pow(4, numIterations);
 
-	Tri* tmp = (Tri*)malloc(maxTris * sizeof(Tri));
-	out_tris[0] = *tri;
-	tmp[0] = *tri;
-	uint32_t numTris = 1;
-	for (int i = 0; i < numIterations; i++) {		
-		for (int j = 0; j < numTris; j++) {
-			SubdivTri(&out_tris[j], tmp + j*4);
-		}
-		numTris <<= 2;
-		memcpy(out_tris, tmp, numTris * sizeof(Tri));
-	}
-	free(tmp);
+    //SubdivTri(tri, out_tris);
+
+    Tri* tmp         = (Tri*)malloc(maxTris * sizeof(Tri));
+    out_tris[ 0 ]    = *tri;
+    tmp[ 0 ]         = *tri;
+    uint32_t numTris = 1;
+    for ( int i = 0; i < numIterations; i++ ) {
+        for ( int j = 0; j < numTris; j++ ) {
+            SubdivTri(&out_tris[ j ], tmp + j * 4);
+        }
+        numTris <<= 2;
+        memcpy(out_tris, tmp, numTris * sizeof(Tri));
+    }
+    free(tmp);
 }
 
 // out_verts are expect to hold 6 vertices
 // out_indices are expected to hold 12 indices
-void SubdivIndexedTri(Vertex* verts, uint32_t numVerts, uint16_t* indices, uint32_t numIndices, Vertex* out_verts, uint16_t* out_indices)
-{
-	if (numVerts < 3) {
-		return;
-	}
+void SubdivIndexedTri(Vertex*   verts,
+                      uint32_t  numVerts,
+                      uint16_t* indices,
+                      uint32_t  numIndices,
+                      Vertex*   out_verts,
+                      uint16_t* out_indices) {
+    if ( numVerts < 3 ) {
+        return;
+    }
 
-	if (numIndices < 3) {
-		return;
-	}
+    if ( numIndices < 3 ) {
+        return;
+    }
 
-	glm::vec3 A = verts[0].pos;
-	glm::vec3 B = verts[1].pos;
-	glm::vec3 C = verts[2].pos;
+    glm::vec3 A = verts[ 0 ].pos;
+    glm::vec3 B = verts[ 1 ].pos;
+    glm::vec3 C = verts[ 2 ].pos;
 
-	glm::vec3 mAB = A + 0.5f * (B - A);
-	glm::vec3 mBC = B + 0.5f * (C - B);
-	glm::vec3 mCA = C + 0.5f * (A - C);
+    glm::vec3 mAB = A + 0.5f * (B - A);
+    glm::vec3 mBC = B + 0.5f * (C - B);
+    glm::vec3 mCA = C + 0.5f * (A - C);
 
-	// find highest index
+    // find highest index
 
-	uint16_t startIndex = 0;
-	for (int i = 0; i < numIndices; i++) {
-		if (indices[i] > startIndex) {
-			startIndex = indices[i];
-		}
-	}
-	startIndex += 1;
+    uint16_t startIndex = 0;
+    for ( int i = 0; i < numIndices; i++ ) {
+        if ( indices[ i ] > startIndex ) {
+            startIndex = indices[ i ];
+        }
+    }
+    startIndex += 1;
 
-	// Put new indices into the buffer
+    // Put new indices into the buffer
 
-	out_indices[0] = indices[0];
-	out_indices[1] = startIndex++;
-	out_indices[2] = startIndex++;
+    out_indices[ 0 ] = indices[ 0 ];
+    out_indices[ 1 ] = startIndex++;
+    out_indices[ 2 ] = startIndex++;
 
-	out_indices[3] = out_indices[1];
-	out_indices[4] = indices[1];
-	out_indices[5] = startIndex++;
+    out_indices[ 3 ] = out_indices[ 1 ];
+    out_indices[ 4 ] = indices[ 1 ];
+    out_indices[ 5 ] = startIndex++;
 
-	out_indices[6] = out_indices[5];
-	out_indices[7] = indices[2];
-	out_indices[8] = out_indices[2];
+    out_indices[ 6 ] = out_indices[ 5 ];
+    out_indices[ 7 ] = indices[ 2 ];
+    out_indices[ 8 ] = out_indices[ 2 ];
 
-	out_indices[9] = out_indices[8];
-	out_indices[10] = out_indices[1];
-	out_indices[11] = out_indices[5];
+    out_indices[ 9 ]  = out_indices[ 8 ];
+    out_indices[ 10 ] = out_indices[ 1 ];
+    out_indices[ 11 ] = out_indices[ 5 ];
 
-	// Now the vertices
+    // Now the vertices
 
-	out_verts[0] = verts[0];
-	out_verts[1] = verts[1];
-	out_verts[2] = verts[2];
-	out_verts[3] = { .pos = mAB };
-	out_verts[4] = { .pos = mCA };
-	out_verts[5] = { .pos = mBC };
+    out_verts[ 0 ] = verts[ 0 ];
+    out_verts[ 1 ] = verts[ 1 ];
+    out_verts[ 2 ] = verts[ 2 ];
+    out_verts[ 3 ] = { .pos = mAB };
+    out_verts[ 4 ] = { .pos = mCA };
+    out_verts[ 5 ] = { .pos = mBC };
 }
 
-void SubdivIndexedTri(Vertex* verts, uint32_t numVerts, uint16_t* indices, uint32_t numIndices, Vertex* out_verts, uint16_t* out_indices, uint32_t numIterations)
-{
-	// TODO: implement
+void SubdivIndexedTri(Vertex*   verts,
+                      uint32_t  numVerts,
+                      uint16_t* indices,
+                      uint32_t  numIndices,
+                      Vertex*   out_verts,
+                      uint16_t* out_indices,
+                      uint32_t  numIterations) {
+    // TODO: implement
 }
 
 // Defined in CCW.
-Quad CreateQuad(glm::vec3 pos, float width, float height, glm::vec4 color)
-{
-	Quad result = {};
-	Tri upperRight = { };
-	Tri lowerLeft = { };
+Quad CreateQuad(glm::vec3 pos, float width, float height, glm::vec4 color) {
+    Quad result     = {};
+    Tri  upperRight = {};
+    Tri  lowerLeft  = {};
 
-	float halfWidth =  width / 2.0f;
-	float halfHeight = height / 2.0f;
+    float halfWidth  = width / 2.0f;
+    float halfHeight = height / 2.0f;
 
-	upperRight.a.pos = glm::vec3(1.0f * halfWidth, 0.0f, -1.0f * halfHeight) + pos;
-	upperRight.a.color = color;
-	upperRight.a.bc = glm::vec3(1.0f, 0.0f, 0.0f);
-	upperRight.a.normal = glm::vec3(0.0f, -1.0f, 0.0f);
-	upperRight.b.pos = glm::vec3(1.0f * halfWidth, 0.0f, 1.0f * halfHeight) + pos;
-	upperRight.b.color = color;
-	upperRight.b.bc = glm::vec3(0.0f, 1.0f, 0.0f);
-	upperRight.b.normal = glm::vec3(0.0f, -1.0f, 0.0f);
-	upperRight.c.pos = glm::vec3(-1.0f * halfWidth, 0.0f, 1.0f * halfHeight) + pos;
-	upperRight.c.color = color;
-	upperRight.c.bc = glm::vec3(0.0f, 0.0f, 1.0f);
-	upperRight.c.normal = glm::vec3(0.0f, -1.0f, 0.0f);
-	lowerLeft.a.pos = glm::vec3(1.0f * halfWidth, 0.0f, -1.0f * halfHeight) + pos;
-	lowerLeft.a.color = color;
-	lowerLeft.a.bc = glm::vec3(1.0f, 0.0f, 0.0f);
-	lowerLeft.a.normal = glm::vec3(0.0f, -1.0f, 0.0f);
-	lowerLeft.b.pos = glm::vec3(-1.0f * halfWidth, 0.0f, 1.0f * halfHeight) + pos;
-	lowerLeft.b.color = color;
-	lowerLeft.b.bc = glm::vec3(0.0f, 1.0f, 0.0f);
-	lowerLeft.b.normal = glm::vec3(0.0f, -1.0f, 0.0f);
-	lowerLeft.c.pos = glm::vec3(-1.0f * halfWidth, 0.0f, -1.0f * halfHeight) + pos;
-	lowerLeft.c.color = color;
-	lowerLeft.c.bc = glm::vec3(0.0f, 0.0f, 1.0f);
-	lowerLeft.c.normal = glm::vec3(0.0f, -1.0f, 0.0f);
+    upperRight.a.pos    = glm::vec3(1.0f * halfWidth, 0.0f, -1.0f * halfHeight) + pos;
+    upperRight.a.color  = color;
+    upperRight.a.bc     = glm::vec3(1.0f, 0.0f, 0.0f);
+    upperRight.a.normal = glm::vec3(0.0f, -1.0f, 0.0f);
+    upperRight.b.pos    = glm::vec3(1.0f * halfWidth, 0.0f, 1.0f * halfHeight) + pos;
+    upperRight.b.color  = color;
+    upperRight.b.bc     = glm::vec3(0.0f, 1.0f, 0.0f);
+    upperRight.b.normal = glm::vec3(0.0f, -1.0f, 0.0f);
+    upperRight.c.pos    = glm::vec3(-1.0f * halfWidth, 0.0f, 1.0f * halfHeight) + pos;
+    upperRight.c.color  = color;
+    upperRight.c.bc     = glm::vec3(0.0f, 0.0f, 1.0f);
+    upperRight.c.normal = glm::vec3(0.0f, -1.0f, 0.0f);
+    lowerLeft.a.pos     = glm::vec3(1.0f * halfWidth, 0.0f, -1.0f * halfHeight) + pos;
+    lowerLeft.a.color   = color;
+    lowerLeft.a.bc      = glm::vec3(1.0f, 0.0f, 0.0f);
+    lowerLeft.a.normal  = glm::vec3(0.0f, -1.0f, 0.0f);
+    lowerLeft.b.pos     = glm::vec3(-1.0f * halfWidth, 0.0f, 1.0f * halfHeight) + pos;
+    lowerLeft.b.color   = color;
+    lowerLeft.b.bc      = glm::vec3(0.0f, 1.0f, 0.0f);
+    lowerLeft.b.normal  = glm::vec3(0.0f, -1.0f, 0.0f);
+    lowerLeft.c.pos     = glm::vec3(-1.0f * halfWidth, 0.0f, -1.0f * halfHeight) + pos;
+    lowerLeft.c.color   = color;
+    lowerLeft.c.bc      = glm::vec3(0.0f, 0.0f, 1.0f);
+    lowerLeft.c.normal  = glm::vec3(0.0f, -1.0f, 0.0f);
 
-	result.a = upperRight;
-	result.b = lowerLeft;
+    result.a = upperRight;
+    result.b = lowerLeft;
 
-	return result;
+    return result;
 }
 
-void RotateQuad(Quad* quad, glm::vec3 axis, float angle)
-{
-	RotateTri(&quad->a, axis, angle);
-	RotateTri(&quad->b, axis, angle);
+void RotateQuad(Quad* quad, glm::vec3 axis, float angle) {
+    RotateTri(&quad->a, axis, angle);
+    RotateTri(&quad->b, axis, angle);
 }
 
-void TranslateQuad(Quad* quad, glm::vec3 t)
-{
-	TranslateTri(&quad->a, t);
-	TranslateTri(&quad->b, t);
+void TranslateQuad(Quad* quad, glm::vec3 t) {
+    TranslateTri(&quad->a, t);
+    TranslateTri(&quad->b, t);
 }
 
-FaceQuad QuadToFace(Quad* quad)
-{
-	return {
-		quad->tl, quad->tr, quad->br, quad->bl
-	};
+FaceQuad QuadToFace(Quad* quad) {
+    return { quad->tl, quad->tr, quad->br, quad->bl };
 }
 
 FaceQuad CreateFaceQuadFromVerts(Vertex* vertices) {
-	FaceQuad fq{};
-	memcpy( fq.vertices, vertices, 4 * sizeof(Vertex) );
-	
-	return fq;
+    FaceQuad fq{};
+    memcpy(fq.vertices, vertices, 4 * sizeof(Vertex));
+
+    return fq;
 }
 
-void SetQuadColor(Quad* quad, glm::vec4 color)
-{
-	SetTriColor(&quad->a, color);
-	SetTriColor(&quad->b, color);
+void SetQuadColor(Quad* quad, glm::vec4 color) {
+    SetTriColor(&quad->a, color);
+    SetTriColor(&quad->b, color);
 }
 
 //Quad front;
@@ -257,161 +252,154 @@ void SetQuadColor(Quad* quad, glm::vec4 color)
 //Quad left;
 //Quad top;
 //Quad bottom;
-Box CreateBox(glm::vec3 scale, glm::vec4 color)
-{
-	Box result = {};
+Box CreateBox(glm::vec3 scale, glm::vec4 color) {
+    Box result = {};
 
-	float halfWidth  = scale.x / 2.0f;
-	float halfDepth  = scale.y / 2.0f;
-	float halfHeight = scale.z / 2.0f;
+    float halfWidth  = scale.x / 2.0f;
+    float halfDepth  = scale.y / 2.0f;
+    float halfHeight = scale.z / 2.0f;
 
-	glm::vec3 up = glm::vec3(0.0f, 0.0f, 1.0f);
+    glm::vec3 up = glm::vec3(0.0f, 0.0f, 1.0f);
 
-	Quad front =  CreateQuad(glm::vec3(0.0f), scale.x, scale.z, color);
-	Quad right =  CreateQuad(glm::vec3(0.0f), scale.y, scale.z, color);
-	Quad back =   CreateQuad(glm::vec3(0.0f), scale.x, scale.z, color);
-	Quad left =   CreateQuad(glm::vec3(0.0f), scale.y, scale.z, color);
-	Quad top =    CreateQuad(glm::vec3(0.0f), scale.x, scale.y, color);
-	Quad bottom = CreateQuad(glm::vec3(0.0f), scale.x, scale.y, color);
-	
-	RotateQuad(&right, up, 90.0f);
-	RotateQuad(&back, up, 180.0f);
-	RotateQuad(&left, up, -90.0f);
-	RotateQuad(&top, glm::vec3(1.0f, 0.0f, 0.0f), -90.0f);
-	RotateQuad(&bottom, glm::vec3(1.0f, 0.0f, 0.0f), 90.0f);
+    Quad front  = CreateQuad(glm::vec3(0.0f), scale.x, scale.z, color);
+    Quad right  = CreateQuad(glm::vec3(0.0f), scale.y, scale.z, color);
+    Quad back   = CreateQuad(glm::vec3(0.0f), scale.x, scale.z, color);
+    Quad left   = CreateQuad(glm::vec3(0.0f), scale.y, scale.z, color);
+    Quad top    = CreateQuad(glm::vec3(0.0f), scale.x, scale.y, color);
+    Quad bottom = CreateQuad(glm::vec3(0.0f), scale.x, scale.y, color);
 
-	TranslateQuad(&front, glm::vec3(0.0f, -1.0f * halfDepth, 0.0f));
-	TranslateQuad(&right, glm::vec3(1.0f * halfWidth, 0.0f, 0.0f));
-	TranslateQuad(&back, glm::vec3(0.0f, 1.0f * halfDepth, 0.0f));
-	TranslateQuad(&left, glm::vec3(-1.0f * halfWidth, 0.0f, 0.0f));
-	TranslateQuad(&top, glm::vec3(0.0f, 0.0f, 1.0f * halfHeight));
-	TranslateQuad(&bottom, glm::vec3(0.0, 0.0, -1.0f * halfHeight));
+    RotateQuad(&right, up, 90.0f);
+    RotateQuad(&back, up, 180.0f);
+    RotateQuad(&left, up, -90.0f);
+    RotateQuad(&top, glm::vec3(1.0f, 0.0f, 0.0f), -90.0f);
+    RotateQuad(&bottom, glm::vec3(1.0f, 0.0f, 0.0f), 90.0f);
 
-	result.front  = front;
-	result.right  = right;
-	result.back   = back;
-	result.left   = left;
-	result.top    = top;
-	result.bottom = bottom;
+    TranslateQuad(&front, glm::vec3(0.0f, -1.0f * halfDepth, 0.0f));
+    TranslateQuad(&right, glm::vec3(1.0f * halfWidth, 0.0f, 0.0f));
+    TranslateQuad(&back, glm::vec3(0.0f, 1.0f * halfDepth, 0.0f));
+    TranslateQuad(&left, glm::vec3(-1.0f * halfWidth, 0.0f, 0.0f));
+    TranslateQuad(&top, glm::vec3(0.0f, 0.0f, 1.0f * halfHeight));
+    TranslateQuad(&bottom, glm::vec3(0.0, 0.0, -1.0f * halfHeight));
 
-	return result;
+    result.front  = front;
+    result.right  = right;
+    result.back   = back;
+    result.left   = left;
+    result.top    = top;
+    result.bottom = bottom;
+
+    return result;
 }
 
-Box CreateBoxFromAABB(glm::vec3 mins, glm::vec3 maxs)
-{
-	float width  = abs(maxs.x - mins.x);
-	float depth  = abs(maxs.y - mins.y);
-	float height = abs(maxs.z - mins.z);
-	glm::vec3 posFix = mins + glm::vec3(width / 2.0f, depth / 2.0f, height / 2.0f);
-	Box result = CreateBox(glm::vec3(width, depth, height), glm::vec4(1.0, 1.0f, 1.0f, 1.0f));
-	TranslateBox(&result, posFix);
+Box CreateBoxFromAABB(glm::vec3 mins, glm::vec3 maxs) {
+    float     width  = abs(maxs.x - mins.x);
+    float     depth  = abs(maxs.y - mins.y);
+    float     height = abs(maxs.z - mins.z);
+    glm::vec3 posFix = mins + glm::vec3(width / 2.0f, depth / 2.0f, height / 2.0f);
+    Box       result = CreateBox(glm::vec3(width, depth, height), glm::vec4(1.0, 1.0f, 1.0f, 1.0f));
+    TranslateBox(&result, posFix);
 
-	return result;
+    return result;
 }
 
-Ellipsoid CreateEllipsoidFromAABB(glm::vec3 mins, glm::vec3 maxs)
-{
-	float width = abs(maxs.x - mins.x);
-	float height = abs(maxs.z - mins.z);
-	Ellipsoid result{};
-	result.radiusA = width / 2.0f;
-	result.radiusB = height / 2.0f;
+Ellipsoid CreateEllipsoidFromAABB(glm::vec3 mins, glm::vec3 maxs) {
+    float     width  = abs(maxs.x - mins.x);
+    float     height = abs(maxs.z - mins.z);
+    Ellipsoid result{};
+    result.radiusA = width / 2.0f;
+    result.radiusB = height / 2.0f;
 
-	float redIncrement = 1.0f / (float)ELLIPSOID_VERT_COUNT;
-	float sliceAngle = 2.0f * HKD_PI / (float)ELLIPSOID_VERT_COUNT;
-	for (int i = 0; i < ELLIPSOID_VERT_COUNT; i++) {
-		Vertex v = {};
-		v.pos.y = 0.0f;
-		v.pos.x = result.radiusA * cosf(i * sliceAngle);
-		v.pos.z = result.radiusB * sinf(i * sliceAngle);
-		v.color = glm::vec4(redIncrement * i, 0.4f, 0.2f, 1.0f);
-		result.vertices[i] = v;
-	}
+    float redIncrement = 1.0f / (float)ELLIPSOID_VERT_COUNT;
+    float sliceAngle   = 2.0f * HKD_PI / (float)ELLIPSOID_VERT_COUNT;
+    for ( int i = 0; i < ELLIPSOID_VERT_COUNT; i++ ) {
+        Vertex v             = {};
+        v.pos.y              = 0.0f;
+        v.pos.x              = result.radiusA * cosf(i * sliceAngle);
+        v.pos.z              = result.radiusB * sinf(i * sliceAngle);
+        v.color              = glm::vec4(redIncrement * i, 0.4f, 0.2f, 1.0f);
+        result.vertices[ i ] = v;
+    }
 
-	return result;
+    return result;
 }
 
 MeshEllipsoid CreateUnitEllipsoid(uint32_t numSubdivs) {
-	NBox unitNbox = CreateNBox(glm::vec3(1.0f), numSubdivs);
+    NBox unitNbox = CreateNBox(glm::vec3(1.0f), numSubdivs);
 
-	// Project box vertices onto unit sphere
-	for (int i = 0; i < unitNbox.tris.size(); i++) {
-		Tri* tri = &unitNbox.tris[i];
-		tri->a.pos = glm::normalize(tri->a.pos);
-		tri->b.pos = glm::normalize(tri->b.pos);
-		tri->c.pos = glm::normalize(tri->c.pos);
-	}
+    // Project box vertices onto unit sphere
+    for ( int i = 0; i < unitNbox.tris.size(); i++ ) {
+        Tri* tri   = &unitNbox.tris[ i ];
+        tri->a.pos = glm::normalize(tri->a.pos);
+        tri->b.pos = glm::normalize(tri->b.pos);
+        tri->c.pos = glm::normalize(tri->c.pos);
+    }
 
-	MeshEllipsoid result;
-	result.radiusA = 1.0f;
-	result.radiusB = 1.0f;
-	result.tris = unitNbox.tris;
+    MeshEllipsoid result;
+    result.radiusA = 1.0f;
+    result.radiusB = 1.0f;
+    result.tris    = unitNbox.tris;
 
-	return result;
+    return result;
 }
 
-void TranslateBox(Box* box, glm::vec3 t)
-{
-	for (int i = 0; i < 6; i++) {
-		Quad* q = &box->quads[i];
-		TranslateQuad(q, t);
-	}
+void TranslateBox(Box* box, glm::vec3 t) {
+    for ( int i = 0; i < 6; i++ ) {
+        Quad* q = &box->quads[ i ];
+        TranslateQuad(q, t);
+    }
 }
 
-void TransformBox(Box* box, glm::mat4 modelMatrix)
-{
-	for (int i = 0; i < 6; i++) {
-		Quad* q = &box->quads[i];
-		for (int j = 0; j < 2; j++) {
-			TransformTri(&q->tris[j], modelMatrix);
-		}
-	}
+void TransformBox(Box* box, glm::mat4 modelMatrix) {
+    for ( int i = 0; i < 6; i++ ) {
+        Quad* q = &box->quads[ i ];
+        for ( int j = 0; j < 2; j++ ) {
+            TransformTri(&q->tris[ j ], modelMatrix);
+        }
+    }
 }
 
-void TransformEllipsoid(Ellipsoid* ellipsoid, glm::mat4 modelMatrix)
-{
-	for (int i = 0; i < ELLIPSOID_VERT_COUNT; i++) {
-		Vertex* v = &ellipsoid->vertices[i];
-		v->pos = modelMatrix * glm::vec4(v->pos, 1.0f);
-	}
+void TransformEllipsoid(Ellipsoid* ellipsoid, glm::mat4 modelMatrix) {
+    for ( int i = 0; i < ELLIPSOID_VERT_COUNT; i++ ) {
+        Vertex* v = &ellipsoid->vertices[ i ];
+        v->pos    = modelMatrix * glm::vec4(v->pos, 1.0f);
+    }
 }
 
-NBox CreateNBox(glm::vec3 scale, uint32_t numSubidvs)
-{
-	NBox result;
-	Box unitBox = CreateBox(scale, glm::vec4(1.0f));
-	std::vector<Tri> currentTris;
-	currentTris.resize(12);
-	memcpy(currentTris.data(), unitBox.tris, 12*sizeof(Tri));
+NBox CreateNBox(glm::vec3 scale, uint32_t numSubidvs) {
+    NBox             result;
+    Box              unitBox = CreateBox(scale, glm::vec4(1.0f));
+    std::vector<Tri> currentTris;
+    currentTris.resize(12);
+    memcpy(currentTris.data(), unitBox.tris, 12 * sizeof(Tri));
 
-	for (int i = 0; i < numSubidvs; i++) {
-		std::vector<Tri> tmp;
-		for (int j = 0; j < currentTris.size(); j++) {
-			Tri out[4];
-			SubdivTri(&currentTris[j], out);
-			tmp.push_back(out[0]);
-			tmp.push_back(out[1]);
-			tmp.push_back(out[2]);
-			tmp.push_back(out[3]);
-		}
-		currentTris = tmp;
-	}
+    for ( int i = 0; i < numSubidvs; i++ ) {
+        std::vector<Tri> tmp;
+        for ( int j = 0; j < currentTris.size(); j++ ) {
+            Tri out[ 4 ];
+            SubdivTri(&currentTris[ j ], out);
+            tmp.push_back(out[ 0 ]);
+            tmp.push_back(out[ 1 ]);
+            tmp.push_back(out[ 2 ]);
+            tmp.push_back(out[ 3 ]);
+        }
+        currentTris = tmp;
+    }
 
-	result.tris = currentTris;
+    result.tris = currentTris;
 
-	return result;
+    return result;
 }
 
 Plane CreatePlaneFromTri(Tri tri) {
-	glm::vec3 AB = tri.b.pos - tri.a.pos;
-	glm::vec3 AC = tri.c.pos - tri.a.pos;
+    glm::vec3 AB = tri.b.pos - tri.a.pos;
+    glm::vec3 AC = tri.c.pos - tri.a.pos;
 
-	glm::vec3 normal = glm::normalize(glm::cross(AB, AC));
-	glm::vec3 A = tri.a.pos;
+    glm::vec3 normal = glm::normalize(glm::cross(AB, AC));
+    glm::vec3 A      = tri.a.pos;
 
-	// Project A onto the normal. That will yield the distance
-	// of the plane from the origin..
-	float d = glm::dot(A, normal);
+    // Project A onto the normal. That will yield the distance
+    // of the plane from the origin..
+    float d = glm::dot(A, normal);
 
-	return { normal, d };
+    return { normal, d };
 }

--- a/r_common.h
+++ b/r_common.h
@@ -2,12 +2,12 @@
 #define _RCOMMON_H_
 
 #include <stdint.h>
-#include <vector>
 #include <string>
+#include <vector>
 
 #define GLM_FORCE_RADIANS
-#include "dependencies/glm/glm.hpp"
 #include "dependencies/glm/ext.hpp"
+#include "dependencies/glm/glm.hpp"
 
 enum ScreenSpaceCoordMode {
     COORD_MODE_ABS,
@@ -24,9 +24,10 @@ struct Vertex {
     glm::vec2 uv;
     glm::vec2 uvLightmap;
     glm::vec3 bc;
-    glm::vec3 normal; // = glm::vec3(0.0f, -1.0f, 0.0f); // points *against* the forward direction (because camera is facing to forward by default)
+    glm::vec3
+        normal; // = glm::vec3(0.0f, -1.0f, 0.0f); // points *against* the forward direction (because camera is facing to forward by default)
     glm::vec4 color;
-    uint32_t  blendindices[4];
+    uint32_t  blendindices[ 4 ];
     glm::vec4 blendweights;
 };
 
@@ -37,33 +38,33 @@ struct StaticVertex {
     glm::vec2 uv;
     glm::vec2 uvLightmap;
     glm::vec3 bc;
-    glm::vec3 normal; // = glm::vec3(0.0f, -1.0f, 0.0f); // points *against* the forward direction (because camera is facing to forward by default)
+    glm::vec3
+        normal; // = glm::vec3(0.0f, -1.0f, 0.0f); // points *against* the forward direction (because camera is facing to forward by default)
     glm::vec3 color;
 };
 
-
 // Vertex Attribute Layout
 
-#define VERT_POS_OFFSET          0
-#define VERT_UV_OFFSET           (VERT_POS_OFFSET + sizeof(glm::vec3))
-#define VERT_UV_LIGHTMAP_OFFSET  (VERT_UV_OFFSET + sizeof(glm::vec2))
-#define VERT_BC_OFFSET           (VERT_UV_LIGHTMAP_OFFSET + sizeof(glm::vec2))
-#define VERT_NORMAL_OFFSET       (VERT_BC_OFFSET + sizeof(glm::vec3))
-#define VERT_COLOR_OFFSET        (VERT_NORMAL_OFFSET + sizeof(glm::vec3))
+#define VERT_POS_OFFSET 0
+#define VERT_UV_OFFSET (VERT_POS_OFFSET + sizeof(glm::vec3))
+#define VERT_UV_LIGHTMAP_OFFSET (VERT_UV_OFFSET + sizeof(glm::vec2))
+#define VERT_BC_OFFSET (VERT_UV_LIGHTMAP_OFFSET + sizeof(glm::vec2))
+#define VERT_NORMAL_OFFSET (VERT_BC_OFFSET + sizeof(glm::vec3))
+#define VERT_COLOR_OFFSET (VERT_NORMAL_OFFSET + sizeof(glm::vec3))
 #define VERT_BLENDINDICES_OFFSET (VERT_COLOR_OFFSET + sizeof(glm::vec4))
-#define VERT_BLENDWEIGHTS_OFFSET (VERT_BLENDINDICES_OFFSET + 4*sizeof(uint32_t))
+#define VERT_BLENDWEIGHTS_OFFSET (VERT_BLENDINDICES_OFFSET + 4 * sizeof(uint32_t))
 
 // Global shader settings
 
 #define SHADER_WIREFRAME_ON_MESH (0x00000001 << 0)
-#define SHADER_LINEMODE          (0x00000001 << 1)
-#define SHADER_ANIMATED          (0x00000001 << 2)
-#define SHADER_IS_TEXTURED       (0x00000001 << 3)
+#define SHADER_LINEMODE (0x00000001 << 1)
+#define SHADER_ANIMATED (0x00000001 << 2)
+#define SHADER_IS_TEXTURED (0x00000001 << 3)
 
-#define GOLDEN_RATIO             1.618033988749
-#define HKD_PI                   3.14159265359
-#define HKD_EPSILON              0.000000001f
-#define ELLIPSOID_VERT_COUNT     32
+#define GOLDEN_RATIO 1.618033988749
+#define HKD_PI 3.14159265359
+#define HKD_EPSILON 0.000000001f
+#define ELLIPSOID_VERT_COUNT 32
 
 struct ShaderSettings {
     glm::uvec4 u32bitMasks; // TODO: This is just to make the Shader happy (Wants 16 bytes by default, not only 4).
@@ -81,13 +82,17 @@ struct ShapesUB {
 
 struct Tri {
     union {
-        struct { Vertex a; Vertex b; Vertex c; };
-        Vertex vertices[3];
+        struct {
+            Vertex a;
+            Vertex b;
+            Vertex c;
+        };
+        Vertex vertices[ 3 ];
     };
 };
 
 struct MapTri {
-    Tri         tri; 
+    Tri         tri;
     std::string textureName;
     std::string lightmap;
     uint64_t    hTexture; // GPU handle set by renderer.
@@ -95,8 +100,11 @@ struct MapTri {
 
 struct Line {
     union {
-        struct { Vertex a; Vertex b; };
-        Vertex vertices[2];
+        struct {
+            Vertex a;
+            Vertex b;
+        };
+        Vertex vertices[ 2 ];
     };
 };
 
@@ -117,8 +125,8 @@ struct Quad {
             Tri a; // top right
             Tri b; // bottom left
         };
-        Tri     tris[2];
-        Vertex  vertices[6];
+        Tri    tris[ 2 ];
+        Vertex vertices[ 6 ];
         struct { // This just makes access to individual vertices easier.
             Vertex tl;
             Vertex tr;
@@ -139,7 +147,7 @@ struct FaceQuad {
             Vertex c;
             Vertex d;
         };
-        Vertex vertices[4];
+        Vertex vertices[ 4 ];
     };
 };
 
@@ -153,8 +161,8 @@ struct Box {
             Quad top;
             Quad bottom;
         };
-        Quad quads[6];
-        Tri  tris[12];
+        Quad quads[ 6 ];
+        Tri  tris[ 12 ];
     };
 };
 
@@ -164,15 +172,15 @@ struct NBox {
 };
 
 struct Ellipsoid {
-    glm::vec3   center;
-    float       radiusA; // horizontal radius
-    float       radiusB; // vertical radius
-    Vertex      vertices[ELLIPSOID_VERT_COUNT];
+    glm::vec3 center;
+    float     radiusA; // horizontal radius
+    float     radiusB; // vertical radius
+    Vertex    vertices[ ELLIPSOID_VERT_COUNT ];
 };
 
 struct MeshEllipsoid {
-    float radiusA;
-    float radiusB;
+    float            radiusA;
+    float            radiusB;
     std::vector<Tri> tris;
 };
 
@@ -182,23 +190,32 @@ void TransformTri(Tri* tri, glm::mat4 modelMatrix);
 void SetTriColor(Tri* tri, glm::vec4 color);
 void SubdivTri(Tri* tri, Tri out_tris[]);
 void SubdivTri(Tri* tri, Tri out_tris[], uint32_t numIterations);
-void SubdivIndexedTri(Vertex* verts, uint32_t numVerts, uint16_t* indices, uint32_t numIndices, Vertex* out_verts, uint16_t* out_indices);
-void SubdivIndexedTri(Vertex* verts, uint32_t numVerts, uint16_t* indices, uint32_t numIndices, Vertex* out_verts, uint16_t* out_indices, uint32_t numIterations);
-Quad CreateQuad(glm::vec3 pos = glm::vec3(0, 0, 0), float width = 1.0f, float height = 1.0f, glm::vec4 color = glm::vec4(1, 0, 0, 1));
-void RotateQuad(Quad* quad, glm::vec3 axis, float angle);
-void TranslateQuad(Quad* quad, glm::vec3 t);
-FaceQuad QuadToFace(Quad* quad);
-FaceQuad CreateFaceQuadFromVerts(Vertex* vertices);
-void SetQuadColor(Quad* quad, glm::vec4 color);
-Box  CreateBox(glm::vec3 scale = glm::vec3(1.0f), glm::vec4 color = glm::vec4(0.2f, 0.2f, 0.2f, 1.0f));
-Box  CreateBoxFromAABB(glm::vec3 mins, glm::vec3 maxs);
-void TranslateBox(Box* box, glm::vec3 t);
-void TransformBox(Box* box, glm::mat4 modelMatrix);
-Ellipsoid CreateEllipsoidFromAABB(glm::vec3 mins, glm::vec3 maxs);
+void SubdivIndexedTri(
+    Vertex* verts, uint32_t numVerts, uint16_t* indices, uint32_t numIndices, Vertex* out_verts, uint16_t* out_indices);
+void          SubdivIndexedTri(Vertex*   verts,
+                               uint32_t  numVerts,
+                               uint16_t* indices,
+                               uint32_t  numIndices,
+                               Vertex*   out_verts,
+                               uint16_t* out_indices,
+                               uint32_t  numIterations);
+Quad          CreateQuad(glm::vec3 pos    = glm::vec3(0, 0, 0),
+                         float     width  = 1.0f,
+                         float     height = 1.0f,
+                         glm::vec4 color  = glm::vec4(1, 0, 0, 1));
+void          RotateQuad(Quad* quad, glm::vec3 axis, float angle);
+void          TranslateQuad(Quad* quad, glm::vec3 t);
+FaceQuad      QuadToFace(Quad* quad);
+FaceQuad      CreateFaceQuadFromVerts(Vertex* vertices);
+void          SetQuadColor(Quad* quad, glm::vec4 color);
+Box           CreateBox(glm::vec3 scale = glm::vec3(1.0f), glm::vec4 color = glm::vec4(0.2f, 0.2f, 0.2f, 1.0f));
+Box           CreateBoxFromAABB(glm::vec3 mins, glm::vec3 maxs);
+void          TranslateBox(Box* box, glm::vec3 t);
+void          TransformBox(Box* box, glm::mat4 modelMatrix);
+Ellipsoid     CreateEllipsoidFromAABB(glm::vec3 mins, glm::vec3 maxs);
 MeshEllipsoid CreateUnitEllipsoid(uint32_t numSubdivs);
-void TransformEllipsoid(Ellipsoid* ellipsoid, glm::mat4 modelMatrix);
-NBox CreateNBox(glm::vec3 scale, uint32_t numSubdivs);
-Plane CreatePlaneFromTri(Tri tri);
+void          TransformEllipsoid(Ellipsoid* ellipsoid, glm::mat4 modelMatrix);
+NBox          CreateNBox(glm::vec3 scale, uint32_t numSubdivs);
+Plane         CreatePlaneFromTri(Tri tri);
 
 #endif
-

--- a/r_font.cpp
+++ b/r_font.cpp
@@ -6,51 +6,47 @@
 #define STB_TRUETYPE_IMPLEMENTATION
 #include "stb_truetype.h"
 
-
-extern std::string  g_GameDir;
+extern std::string g_GameDir;
 
 // TODO: (Michael): Set bitmap size through ctor
 // or compute it through provided size to fit all glyphs.
-CFont::CFont(std::string fontFile, float size) { 
+CFont::CFont(std::string fontFile, float size) {
     m_Filename = fontFile + std::to_string(size);
-    m_Size = size;
-    m_Cdata = (stbtt_bakedchar*)malloc( NUM_GLYPHS * sizeof(stbtt_bakedchar) ); 
-    m_Bitmap = (unsigned char*)malloc( FONT_TEX_SIZE * FONT_TEX_SIZE );
-    
+    m_Size     = size;
+    m_Cdata    = (stbtt_bakedchar*)malloc(NUM_GLYPHS * sizeof(stbtt_bakedchar));
+    m_Bitmap   = (unsigned char*)malloc(FONT_TEX_SIZE * FONT_TEX_SIZE);
+
     // Read TTF file into buffer.
-    unsigned char* ttfFileData = (unsigned char*)malloc( 1<<20 );
-    std::string fontFilePath = g_GameDir + fontFile;
-    fread( (void*)ttfFileData, 1, 1<<20, 
-	  fopen(fontFilePath.c_str(), "rb") );
-    
-    stbtt_InitFont( &m_FontInfo, ttfFileData, stbtt_GetFontOffsetForIndex(ttfFileData, 0) );
+    unsigned char* ttfFileData  = (unsigned char*)malloc(1 << 20);
+    std::string    fontFilePath = g_GameDir + fontFile;
+    fread((void*)ttfFileData, 1, 1 << 20, fopen(fontFilePath.c_str(), "rb"));
+
+    stbtt_InitFont(&m_FontInfo, ttfFileData, stbtt_GetFontOffsetForIndex(ttfFileData, 0));
 
     // Create a bitmap containing all the glyphs. A gpu texture may be
     // created from that bitmap. m_Cdata can then be queried to get rectangles for the glyphs.
     // stbtt_BakeFontBitmap( ttfFileData, 0, (float)size, m_Bitmap, 512, 512, 32, NUM_GLYPHS, m_Cdata );
 
-
     // Better API (apparently)
 
     stbtt_pack_context pc;
-    stbtt_PackBegin( &pc, m_Bitmap, FONT_TEX_SIZE, FONT_TEX_SIZE, 0, 1, 0 );
+    stbtt_PackBegin(&pc, m_Bitmap, FONT_TEX_SIZE, FONT_TEX_SIZE, 0, 1, 0);
 
-    m_PackedCharData = (stbtt_packedchar*)malloc( NUM_GLYPHS * sizeof(stbtt_packedchar) );
-    if ( stbtt_PackFontRange( 
-	    &pc, ttfFileData, 0, STBTT_POINT_SIZE(size), 
-	    FIRST_CODE_POINT, NUM_GLYPHS, 
-	    m_PackedCharData ) != 1 ) {
-	printf("STBTT (PackFontRange): Failed to pack font data.\n");
+    m_PackedCharData = (stbtt_packedchar*)malloc(NUM_GLYPHS * sizeof(stbtt_packedchar));
+    if ( stbtt_PackFontRange(
+             &pc, ttfFileData, 0, STBTT_POINT_SIZE(size), FIRST_CODE_POINT, NUM_GLYPHS, m_PackedCharData)
+         != 1 ) {
+        printf("STBTT (PackFontRange): Failed to pack font data.\n");
     }
 
     stbtt_PackEnd(&pc);
 
     // Get global ascender. The highest vertical offset to the baseline.
-    float scale = stbtt_ScaleForPixelHeight( &m_FontInfo, size );
-    stbtt_GetFontVMetrics( &m_FontInfo, &m_Ascender, &m_Descender, 0 );
-    
+    float scale = stbtt_ScaleForPixelHeight(&m_FontInfo, size);
+    stbtt_GetFontVMetrics(&m_FontInfo, &m_Ascender, &m_Descender, 0);
+
     // Scale to pixel values
-    m_Ascender = (float)m_Ascender * scale;
+    m_Ascender  = (float)m_Ascender * scale;
     m_Descender = (float)m_Ascender * scale;
 
     // Cleanup
@@ -62,4 +58,3 @@ CFont::~CFont() {
     free(m_Bitmap);
     free(m_PackedCharData);
 }
-

--- a/r_font.h
+++ b/r_font.h
@@ -7,25 +7,24 @@
 #include <vector>
 
 const int FIRST_CODE_POINT = 32; // Space (ASCII and Unicode overlap)
-const int NUM_GLYPHS = 96;
-const int LAST_CODE_POINT = FIRST_CODE_POINT + NUM_GLYPHS;
-const int FONT_TEX_SIZE = 1024;
+const int NUM_GLYPHS       = 96;
+const int LAST_CODE_POINT  = FIRST_CODE_POINT + NUM_GLYPHS;
+const int FONT_TEX_SIZE    = 1024;
 
 class CFont {
 
-public:
+  public:
     CFont(std::string fontFile, float size);
     ~CFont();
 
-    float	      m_Size;
-    std::string	      m_Filename;
+    float             m_Size;
+    std::string       m_Filename;
     unsigned char*    m_Bitmap;
     stbtt_bakedchar*  m_Cdata; // glyphs
     stbtt_fontinfo    m_FontInfo;
     stbtt_packedchar* m_PackedCharData;
     int               m_Ascender;
-    int		      m_Descender;
+    int               m_Descender;
 };
 
 #endif
-

--- a/r_gl.cpp
+++ b/r_gl.cpp
@@ -10,13 +10,13 @@
 #include "stb_truetype.h"
 
 #include "imgui.h"
-#include <imgui/backends/imgui_impl_sdl2.h>
-#include <imgui/backends/imgui_impl_opengl3.h>
 #include <SDL2/SDL_egl.h>
+#include <imgui/backends/imgui_impl_opengl3.h>
+#include <imgui/backends/imgui_impl_sdl2.h>
 
 #define GLM_FORCE_RADIANS
-#include "dependencies/glm/glm.hpp"
 #include "dependencies/glm/ext.hpp"
+#include "dependencies/glm/glm.hpp"
 
 #include "Console/Console.h"
 #include "Console/VariableManager.h"
@@ -29,52 +29,93 @@
 #include "r_gl_texture_mgr.h"
 #include "r_itexture.h"
 
-const int WINDOW_WIDTH = 1920;
+const int WINDOW_WIDTH  = 1920;
 const int WINDOW_HEIGHT = 1080;
 
-ConsoleVariable scr_consize = {"scr_consize", 0.45f};
-ConsoleVariable scr_conopacity = {"scr_conopacity", 0.95f};
-ConsoleVariable scr_conwraplines = {"scr_conwraplines", 1};
+ConsoleVariable scr_consize      = { "scr_consize", 0.45f };
+ConsoleVariable scr_conopacity   = { "scr_conopacity", 0.95f };
+ConsoleVariable scr_conwraplines = { "scr_conwraplines", 1 };
 
-
-void GLAPIENTRY OpenGLDebugCallback(GLenum source, GLenum type, GLuint id, GLenum severity,
-                                    GLsizei length, const GLchar* message, const void* userParam) {
+void GLAPIENTRY OpenGLDebugCallback(GLenum        source,
+                                    GLenum        type,
+                                    GLuint        id,
+                                    GLenum        severity,
+                                    GLsizei       length,
+                                    const GLchar* message,
+                                    const void*   userParam) {
     // Ignore non-significant error/warning codes (e.g., vendor-specific warnings)
-    if (id == 131169 || id == 131185 || id == 131218 || id == 131204)
-        return;
+    if ( id == 131169 || id == 131185 || id == 131218 || id == 131204 ) return;
 
     printf("--------------------- OpenGL Debug Output ---------------------\n");
     printf("Message: %s\n", message);
 
     printf("Source: ");
-    switch (source) {
-        case GL_DEBUG_SOURCE_API:             printf("API\n"); break;
-        case GL_DEBUG_SOURCE_WINDOW_SYSTEM:   printf("Window System\n"); break;
-        case GL_DEBUG_SOURCE_SHADER_COMPILER: printf("Shader Compiler\n"); break;
-        case GL_DEBUG_SOURCE_THIRD_PARTY:     printf("Third Party\n"); break;
-        case GL_DEBUG_SOURCE_APPLICATION:     printf("Application\n"); break;
-        case GL_DEBUG_SOURCE_OTHER:           printf("Other\n"); break;
+    switch ( source ) {
+    case GL_DEBUG_SOURCE_API:
+        printf("API\n");
+        break;
+    case GL_DEBUG_SOURCE_WINDOW_SYSTEM:
+        printf("Window System\n");
+        break;
+    case GL_DEBUG_SOURCE_SHADER_COMPILER:
+        printf("Shader Compiler\n");
+        break;
+    case GL_DEBUG_SOURCE_THIRD_PARTY:
+        printf("Third Party\n");
+        break;
+    case GL_DEBUG_SOURCE_APPLICATION:
+        printf("Application\n");
+        break;
+    case GL_DEBUG_SOURCE_OTHER:
+        printf("Other\n");
+        break;
     }
 
     printf("Type: ");
-    switch (type) {
-        case GL_DEBUG_TYPE_ERROR:               printf("Error\n"); break;
-        case GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR: printf("Deprecated Behaviour\n"); break;
-        case GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR:  printf("Undefined Behaviour\n"); break;
-        case GL_DEBUG_TYPE_PORTABILITY:         printf("Portability\n"); break;
-        case GL_DEBUG_TYPE_PERFORMANCE:         printf("Performance\n"); break;
-        case GL_DEBUG_TYPE_MARKER:              printf("Marker\n"); break;
-        case GL_DEBUG_TYPE_PUSH_GROUP:          printf("Push Group\n"); break;
-        case GL_DEBUG_TYPE_POP_GROUP:           printf("Pop Group\n"); break;
-        case GL_DEBUG_TYPE_OTHER:               printf("Other\n"); break;
+    switch ( type ) {
+    case GL_DEBUG_TYPE_ERROR:
+        printf("Error\n");
+        break;
+    case GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR:
+        printf("Deprecated Behaviour\n");
+        break;
+    case GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR:
+        printf("Undefined Behaviour\n");
+        break;
+    case GL_DEBUG_TYPE_PORTABILITY:
+        printf("Portability\n");
+        break;
+    case GL_DEBUG_TYPE_PERFORMANCE:
+        printf("Performance\n");
+        break;
+    case GL_DEBUG_TYPE_MARKER:
+        printf("Marker\n");
+        break;
+    case GL_DEBUG_TYPE_PUSH_GROUP:
+        printf("Push Group\n");
+        break;
+    case GL_DEBUG_TYPE_POP_GROUP:
+        printf("Pop Group\n");
+        break;
+    case GL_DEBUG_TYPE_OTHER:
+        printf("Other\n");
+        break;
     }
 
     printf("Severity: ");
-    switch (severity) {
-        case GL_DEBUG_SEVERITY_HIGH:         printf("High\n"); break;
-        case GL_DEBUG_SEVERITY_MEDIUM:       printf("Medium\n"); break;
-        case GL_DEBUG_SEVERITY_LOW:          printf("Low\n"); break;
-        case GL_DEBUG_SEVERITY_NOTIFICATION: printf("Notification\n"); break;
+    switch ( severity ) {
+    case GL_DEBUG_SEVERITY_HIGH:
+        printf("High\n");
+        break;
+    case GL_DEBUG_SEVERITY_MEDIUM:
+        printf("Medium\n");
+        break;
+    case GL_DEBUG_SEVERITY_LOW:
+        printf("Low\n");
+        break;
+    case GL_DEBUG_SEVERITY_NOTIFICATION:
+        printf("Notification\n");
+        break;
     }
     printf("---------------------------------------------------------------\n");
 }
@@ -139,21 +180,19 @@ bool GLRender::Init(void) {
     SDL_Init(SDL_INIT_EVERYTHING);
 
     // From 2.0.18: Enable native IME.
-/*
+    /*
 #ifdef SDL_HINT_IME_SHOW_UI
     SDL_SetHint(SDL_HINT_IME_SHOW_UI, "1");
 #endif
 */
 
     // Create an application window with the following settings:
-    m_Window = SDL_CreateWindow(
-        "HKD",
-        SDL_WINDOWPOS_UNDEFINED,
-        SDL_WINDOWPOS_UNDEFINED,
-        WINDOW_WIDTH,
-        WINDOW_HEIGHT,
-        SDL_WINDOW_OPENGL | SDL_WINDOW_ALLOW_HIGHDPI
-    );
+    m_Window = SDL_CreateWindow("HKD",
+                                SDL_WINDOWPOS_UNDEFINED,
+                                SDL_WINDOWPOS_UNDEFINED,
+                                WINDOW_WIDTH,
+                                WINDOW_HEIGHT,
+                                SDL_WINDOW_OPENGL | SDL_WINDOW_ALLOW_HIGHDPI);
 
     // BEWARE! These flags must be set AFTER SDL_CreateWindow. Otherwise SDL
     // just doesn't cate about them (at least on Linux)!
@@ -172,7 +211,7 @@ bool GLRender::Init(void) {
     SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8);
 
     m_SDL_GL_Conext = SDL_GL_CreateContext(m_Window);
-    if (!m_SDL_GL_Conext) {
+    if ( !m_SDL_GL_Conext ) {
         SDL_Log("Unable to create GL context! SDL-Error: %s\n", SDL_GetError());
         return false;
     }
@@ -185,7 +224,7 @@ bool GLRender::Init(void) {
     SDL_GL_GetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, &minorVersion);
     printf("OpenGL Version active: %d.%d\n", majorVersion, minorVersion);
 
-    if (!gladLoadGLLoader((GLADloadproc)SDL_GL_GetProcAddress)) {
+    if ( !gladLoadGLLoader((GLADloadproc)SDL_GL_GetProcAddress) ) {
         SDL_Log("Failed to get OpenGL function pointers via GLAD: %s\n", SDL_GetError());
         return false;
     }
@@ -195,10 +234,9 @@ bool GLRender::Init(void) {
     // Allow OpenGL to send us debug information.
     EnableOpenGLDebugCallback();
 
-
     // Check that the window was successfully created
 
-    if (m_Window == NULL) {
+    if ( m_Window == NULL ) {
         // In the case that the window could not be made...
         SDL_Log("Could not create window: %s\n", SDL_GetError());
         return false;
@@ -207,10 +245,9 @@ bool GLRender::Init(void) {
     SDL_ShowWindow(m_Window);
 
     // GL Vsync on
-    if (SDL_GL_SetSwapInterval(1) != 0) {
+    if ( SDL_GL_SetSwapInterval(1) != 0 ) {
         SDL_Log("Failed to enable vsync!\n");
-    }
-    else {
+    } else {
         SDL_Log("vsync enabled\n");
     }
 
@@ -238,7 +275,7 @@ bool GLRender::Init(void) {
 
     // Some OpenGL Info
 
-    const GLubyte* vendor = glGetString(GL_VENDOR);
+    const GLubyte* vendor   = glGetString(GL_VENDOR);
     const GLubyte* renderer = glGetString(GL_RENDERER);
     SDL_Log("%s, %s\n", vendor, renderer);
 
@@ -253,13 +290,13 @@ bool GLRender::Init(void) {
     m_ModelBatch = new GLBatch(500 * 1000);
 
     // Batches but for different purposes
-    m_ImPrimitiveBatch = new GLBatch(1000);
+    m_ImPrimitiveBatch        = new GLBatch(1000);
     m_ImPrimitiveBatchIndexed = new GLBatch(1000, 1000);
-    m_ColliderBatch = new GLBatch(1000);
-    m_FontBatch = new GLBatch(1000, 1000);
-    m_ShapesBatch = new GLBatch(1000, 1000);
-    m_WorldBatch = new GLBatch(100000);
-    m_BrushBatch = new GLBatch(50000);
+    m_ColliderBatch           = new GLBatch(1000);
+    m_FontBatch               = new GLBatch(1000, 1000);
+    m_ShapesBatch             = new GLBatch(1000, 1000);
+    m_WorldBatch              = new GLBatch(100000);
+    m_BrushBatch              = new GLBatch(50000);
 
     // Initialize shaders
 
@@ -288,25 +325,21 @@ bool GLRender::Init(void) {
 
 // At the moment we don't generate a drawCmd for a model. We just but all of
 // the meshes into a GPU buffer and draw all of them exactly the same way.
-int GLRender::RegisterModel(HKD_Model* model)
-{
+int GLRender::RegisterModel(HKD_Model* model) {
     GLModel gl_model = {};
-    int offset = m_ModelBatch->Add(&model->tris[0], model->tris.size());
+    int     offset   = m_ModelBatch->Add(&model->tris[ 0 ], model->tris.size());
 
-    for (int i = 0; i < model->meshes.size(); i++) {
-        HKD_Mesh* mesh = &model->meshes[i];
+    for ( int i = 0; i < model->meshes.size(); i++ ) {
+        HKD_Mesh*  mesh    = &model->meshes[ i ];
         GLTexture* texture = (GLTexture*)m_TextureManager->CreateTexture(mesh->textureFileName);
-        GLMesh gl_mesh = {
-            .triOffset = offset/3 + (int)mesh->firstTri,
-            .triCount = (int)mesh->numTris,
-            .texture = texture
-        };
+        GLMesh     gl_mesh
+            = { .triOffset = offset / 3 + (int)mesh->firstTri, .triCount = (int)mesh->numTris, .texture = texture };
         gl_model.meshes.push_back(gl_mesh);
     }
 
     m_Models.push_back(gl_model);
 
-    int gpuModelHandle = m_Models.size() - 1;
+    int gpuModelHandle    = m_Models.size() - 1;
     model->gpuModelHandle = gpuModelHandle;
 
     return gpuModelHandle;
@@ -315,22 +348,19 @@ int GLRender::RegisterModel(HKD_Model* model)
 // FIX: Same as RegisterModel just with a different batch!
 int GLRender::RegisterBrush(HKD_Model* model) {
     GLModel gl_model = {};
-    int offset = m_BrushBatch->Add(&model->tris[0], model->tris.size());
+    int     offset   = m_BrushBatch->Add(&model->tris[ 0 ], model->tris.size());
 
-    for (int i = 0; i < model->meshes.size(); i++) {
-        HKD_Mesh* mesh = &model->meshes[i];
+    for ( int i = 0; i < model->meshes.size(); i++ ) {
+        HKD_Mesh*  mesh    = &model->meshes[ i ];
         GLTexture* texture = (GLTexture*)m_TextureManager->CreateTexture(mesh->textureFileName);
-        GLMesh gl_mesh = {
-            .triOffset = offset/3 + (int)mesh->firstTri,
-            .triCount = (int)mesh->numTris,
-            .texture = texture
-        };
+        GLMesh     gl_mesh
+            = { .triOffset = offset / 3 + (int)mesh->firstTri, .triCount = (int)mesh->numTris, .texture = texture };
         gl_model.meshes.push_back(gl_mesh);
     }
 
     m_Models.push_back(gl_model);
 
-    int gpuModelHandle = m_Models.size() - 1;
+    int gpuModelHandle    = m_Models.size() - 1;
     model->gpuModelHandle = gpuModelHandle;
 
     return gpuModelHandle;
@@ -341,13 +371,13 @@ void GLRender::RegisterFont(CFont* font) {
 }
 
 void GLRender::RegisterWorld(CWorld* world) {
-    std::vector<MapTri>& tris = world->GetMapTris();
-    uint64_t numStaticTris = world->StaticGeometryCount();
+    std::vector<MapTri>& tris          = world->GetMapTris();
+    uint64_t             numStaticTris = world->StaticGeometryCount();
 
     // Sort static Tris by texture
-    std::unordered_map<uint64_t, std::vector<MapTri> > texHandle2Tris{};
+    std::unordered_map<uint64_t, std::vector<MapTri>> texHandle2Tris{};
 
-    for (int i = 0; i < numStaticTris; i++) {
+    for ( int i = 0; i < numStaticTris; i++ ) {
         MapTri pTri = tris[ i ];
         if ( texHandle2Tris.contains(pTri.hTexture) ) {
             std::vector<MapTri>& triList = texHandle2Tris.at(pTri.hTexture);
@@ -361,18 +391,16 @@ void GLRender::RegisterWorld(CWorld* world) {
     // Upload tris to GPU and generate draw cmds.
 
     // FIX: ALL tris are registered here. Brush entities should go into a dedicated dynamic batch.
-    for (auto& [ texHandle, triList ] : texHandle2Tris) {
+    for ( auto& [ texHandle, triList ] : texHandle2Tris ) {
         std::vector<MapTri> pTris = triList;
-        int vertexOffset = m_WorldBatch->AddMapTris( pTris.data(), triList.size(), true, DRAW_MODE_SOLID );
-        assert( vertexOffset >= 0 && "Tried to add Tris to World Batch but it returned a negative offset!" );
-        GLBatchDrawCmd drawCmd = {
-            vertexOffset, // Vertex Buffer offset is the current vert count of the batch
-            0, // Index buffer offset.  Ignored: World is drawn without indices
-            triList.size() * 3, // Num vertices (3 per tri)
-            0, // Num indices: irgnored
-            true, // Cull back faces
-            DRAW_MODE_SOLID
-        };
+        int vertexOffset          = m_WorldBatch->AddMapTris(pTris.data(), triList.size(), true, DRAW_MODE_SOLID);
+        assert(vertexOffset >= 0 && "Tried to add Tris to World Batch but it returned a negative offset!");
+        GLBatchDrawCmd drawCmd = { vertexOffset,       // Vertex Buffer offset is the current vert count of the batch
+                                   0,                  // Index buffer offset.  Ignored: World is drawn without indices
+                                   triList.size() * 3, // Num vertices (3 per tri)
+                                   0,                  // Num indices: irgnored
+                                   true,               // Cull back faces
+                                   DRAW_MODE_SOLID };
         m_TexHandleToWorldDrawCmd.insert({ texHandle, drawCmd });
     }
 }
@@ -382,70 +410,59 @@ uint64_t GLRender::RegisterTextureGetHandle(std::string name) {
     return m_TextureManager->CreateTextureGetHandle(name);
 }
 
-void GLRender::SetActiveCamera(Camera* camera)
-{
+void GLRender::SetActiveCamera(Camera* camera) {
     m_ActiveCamera = camera;
 }
 
-void GLRender::RegisterColliderModels()
-{
+void GLRender::RegisterColliderModels() {
     // Generate vertices for a circle. Used for ellipsoid colliders.
 
     MeshEllipsoid unitEllipsoid = CreateUnitEllipsoid(2);
 
     m_EllipsoidColliderDrawCmd = AddTrisToBatch(
-        m_ColliderBatch,
-        unitEllipsoid.tris.data(), unitEllipsoid.tris.size(),
-        false, DRAW_MODE_WIREFRAME);
+        m_ColliderBatch, unitEllipsoid.tris.data(), unitEllipsoid.tris.size(), false, DRAW_MODE_WIREFRAME);
 }
 
 // Maybe return a void* as GPU handle, because usually APIs that use the handle of
 // a specific graphics API don't expect it to be in int or whatever.
-std::vector<ITexture*> GLRender::ModelTextures(int gpuModelHandle)
-{
+std::vector<ITexture*> GLRender::ModelTextures(int gpuModelHandle) {
     std::vector<ITexture*> results;
 
-    if (gpuModelHandle >= m_Models.size()) return results;
-    else if (gpuModelHandle < 0)           return results;
+    if ( gpuModelHandle >= m_Models.size() )
+        return results;
+    else if ( gpuModelHandle < 0 )
+        return results;
 
-    GLModel* model = &m_Models[gpuModelHandle];
-    for (auto& mesh : model->meshes) {
-        results.push_back( mesh.texture );
+    GLModel* model = &m_Models[ gpuModelHandle ];
+    for ( auto& mesh : model->meshes ) {
+        results.push_back(mesh.texture);
     }
 
     return results;
 }
 
-std::vector<ITexture*> GLRender::Textures(void)
-{
+std::vector<ITexture*> GLRender::Textures(void) {
     std::vector<ITexture*> result;
-    for (auto& elem: m_TextureManager->m_NameToTexture) {
+    for ( auto& elem : m_TextureManager->m_NameToTexture ) {
         result.push_back(elem.second);
     }
 
     return result;
 }
 
-void GLRender::ImDrawTris(Tri* tris, uint32_t numTris, bool cullFace, DrawMode drawMode)
-{
+void GLRender::ImDrawTris(Tri* tris, uint32_t numTris, bool cullFace, DrawMode drawMode) {
     int offset = m_ImPrimitiveBatch->Add(tris, numTris, cullFace, drawMode);
 
-    GLBatchDrawCmd drawCmd = {
-        .offset = offset,
-        .numVerts = 3 * numTris,
-        .cullFace = cullFace,
-        .drawMode = drawMode
-    };
+    GLBatchDrawCmd drawCmd = { .offset = offset, .numVerts = 3 * numTris, .cullFace = cullFace, .drawMode = drawMode };
 
     m_PrimitiveDrawCmds.push_back(drawCmd);
 }
 
-void GLRender::ImDrawTriPlanes(TriPlane* triPlanes, uint32_t numTriPlanes, bool cullFace, DrawMode drawMode)
-{
+void GLRender::ImDrawTriPlanes(TriPlane* triPlanes, uint32_t numTriPlanes, bool cullFace, DrawMode drawMode) {
     std::vector<Tri> tris;
     tris.resize(numTriPlanes);
-    for (int i = 0; i < numTriPlanes; i++) {
-        tris[i] = triPlanes[i].tri;
+    for ( int i = 0; i < numTriPlanes; i++ ) {
+        tris[ i ] = triPlanes[ i ].tri;
     }
     ImDrawTris(tris.data(), numTriPlanes, cullFace, drawMode);
 }
@@ -453,54 +470,42 @@ void GLRender::ImDrawTriPlanes(TriPlane* triPlanes, uint32_t numTriPlanes, bool 
 GLBatchDrawCmd GLRender::AddTrisToBatch(GLBatch* batch, Tri* tris, uint32_t numTris, bool cullFace, DrawMode drawMode) {
     int offset = batch->Add(tris, numTris, cullFace, drawMode);
 
-    GLBatchDrawCmd drawCmd = {
-        .offset = offset,
-        .numVerts = 3 * numTris,
-        .cullFace = cullFace,
-        .drawMode = drawMode
-    };
+    GLBatchDrawCmd drawCmd = { .offset = offset, .numVerts = 3 * numTris, .cullFace = cullFace, .drawMode = drawMode };
 
     return drawCmd;
 }
 
 // Draw triangles with indexed geometry :)
-void GLRender::ImDrawIndexed(Vertex* verts, uint32_t numVerts, uint16_t* indices, uint32_t numIndices, bool cullFace, DrawMode drawMode)
-{
-    int offset = 0;
+void GLRender::ImDrawIndexed(
+    Vertex* verts, uint32_t numVerts, uint16_t* indices, uint32_t numIndices, bool cullFace, DrawMode drawMode) {
+    int offset        = 0;
     int offsetIndices = 0;
-    if (!m_ImPrimitiveBatchIndexed->Add(verts, numVerts, indices, numIndices, &offset, &offsetIndices, cullFace, drawMode)) {
+    if ( !m_ImPrimitiveBatchIndexed->Add(
+             verts, numVerts, indices, numIndices, &offset, &offsetIndices, cullFace, drawMode) ) {
         return;
     }
 
-    GLBatchDrawCmd drawCmd = {
-        .offset = offset,
-        .indexOffset = offsetIndices,
-        .numVerts = numVerts,
-        .numIndices = numIndices,
-        .cullFace = cullFace,
-        .drawMode = drawMode
-    };
+    GLBatchDrawCmd drawCmd = { .offset      = offset,
+                               .indexOffset = offsetIndices,
+                               .numVerts    = numVerts,
+                               .numIndices  = numIndices,
+                               .cullFace    = cullFace,
+                               .drawMode    = drawMode };
 
     m_PrimitiveIndexdDrawCmds.push_back(drawCmd);
 }
 
 // TODO: not done
-void GLRender::ImDrawVerts(Vertex* verts, uint32_t numVerts)
-{
+void GLRender::ImDrawVerts(Vertex* verts, uint32_t numVerts) {
     int offset = m_ImPrimitiveBatch->Add(verts, numVerts);
 
-    GLBatchDrawCmd drawCmd = {
-        .offset = offset,
-        .numVerts = numVerts,
-        .cullFace = false,
-        .drawMode = DRAW_MODE_SOLID
-    };
+    GLBatchDrawCmd drawCmd = { .offset = offset, .numVerts = numVerts, .cullFace = false, .drawMode = DRAW_MODE_SOLID };
 }
 
 void GLRender::ImDrawCircle(glm::vec3 center, float radius, glm::vec3 normal) {
     int                 segments = 32;
     std::vector<Vertex> circleVerts;
-    float               step = glm::two_pi<float>() / (float)segments;
+    float               step        = glm::two_pi<float>() / (float)segments;
     glm::mat3           rotationMat = glm::mat3(1.0);
     if ( normal != DOD_WORLD_UP ) {
         glm::vec3 axis = glm::cross(DOD_WORLD_UP, glm::normalize(normal));
@@ -535,54 +540,46 @@ void GLRender::ImDrawLines(Vertex* verts, uint32_t numVerts, bool close) {
     int offset = m_ImPrimitiveBatch->Add(v, 2, false, DRAW_MODE_LINES);
     v += 1;
     int moreVerts = 0;
-    for (int i = 2; i < numVerts; i++) {
+    for ( int i = 2; i < numVerts; i++ ) {
         m_ImPrimitiveBatch->Add(v, 2, false, DRAW_MODE_LINES);
         v++;
         moreVerts += 1;
     }
 
-    if (close) {
-        Vertex endAndStart[] = { *v, verts[0] };
+    if ( close ) {
+        Vertex endAndStart[] = { *v, verts[ 0 ] };
         m_ImPrimitiveBatch->Add(endAndStart, 2, false, DRAW_MODE_LINES);
         moreVerts += 2;
     }
 
-    GLBatchDrawCmd drawCmd = {
-        .offset = offset,
-        .numVerts = numVerts + moreVerts,
-        .cullFace = false,
-        .drawMode = DRAW_MODE_LINES
-    };
+    GLBatchDrawCmd drawCmd
+        = { .offset = offset, .numVerts = numVerts + moreVerts, .cullFace = false, .drawMode = DRAW_MODE_LINES };
 
     m_PrimitiveDrawCmds.push_back(drawCmd);
 }
 
-void GLRender::ImDrawSphere(glm::vec3 pos, float radius, glm::vec4 color)
-{
+void GLRender::ImDrawSphere(glm::vec3 pos, float radius, glm::vec4 color) {
     glm::mat4 view = m_ActiveCamera->ViewMatrix();
     // TODO: Global Setting for perspective values
-    glm::mat4 proj = glm::perspective(
-        glm::radians(45.0f),
-        (float)m_WindowWidth / (float)m_WindowHeight,
-        0.1f, 10000.0f);
+    glm::mat4 proj
+        = glm::perspective(glm::radians(45.0f), (float)m_WindowWidth / (float)m_WindowHeight, 0.1f, 10000.0f);
 
     m_ColliderShader->Activate();
     m_ColliderShader->SetViewProjMatrices(view, proj);
 
     m_ColliderBatch->Bind();
-        m_ColliderShader->SetVec4("uDebugColor", color);
-        glm::vec3 scale = glm::vec3(radius);
-        glm::mat4 T = glm::translate(glm::mat4(1.0f), pos);
-        glm::mat4 S = glm::scale(glm::mat4(1.0f), scale);
-        glm::mat4 M = T * S;
-        m_ColliderShader->SetMat4("model", M);
+    m_ColliderShader->SetVec4("uDebugColor", color);
+    glm::vec3 scale = glm::vec3(radius);
+    glm::mat4 T     = glm::translate(glm::mat4(1.0f), pos);
+    glm::mat4 S     = glm::scale(glm::mat4(1.0f), scale);
+    glm::mat4 M     = T * S;
+    m_ColliderShader->SetMat4("model", M);
 
-        glDrawArrays(GL_TRIANGLES, m_EllipsoidColliderDrawCmd.offset, m_EllipsoidColliderDrawCmd.numVerts);
+    glDrawArrays(GL_TRIANGLES, m_EllipsoidColliderDrawCmd.offset, m_EllipsoidColliderDrawCmd.numVerts);
 }
 
-GLBatchDrawCmd GLRender::AddLineToBatch(GLBatch* batch, Vertex* verts, uint32_t numVerts, bool close)
-{
-    if (numVerts < 2) { // This won't work, man.
+GLBatchDrawCmd GLRender::AddLineToBatch(GLBatch* batch, Vertex* verts, uint32_t numVerts, bool close) {
+    if ( numVerts < 2 ) { // This won't work, man.
         return { -1 };
     }
 
@@ -591,30 +588,25 @@ GLBatchDrawCmd GLRender::AddLineToBatch(GLBatch* batch, Vertex* verts, uint32_t 
     int offset = batch->Add(v, 2, false, DRAW_MODE_LINES);
     v += 1;
     int moreVerts = 0;
-    for (int i = 2; i < numVerts; i++) {
+    for ( int i = 2; i < numVerts; i++ ) {
         batch->Add(v, 2, false, DRAW_MODE_LINES);
         v++;
         moreVerts += 1;
     }
 
-    if (close) {
-        Vertex endAndStart[] = { *v, verts[0] };
+    if ( close ) {
+        Vertex endAndStart[] = { *v, verts[ 0 ] };
         batch->Add(endAndStart, 2, false, DRAW_MODE_LINES);
         moreVerts += 2;
     }
 
-    GLBatchDrawCmd drawCmd = {
-        .offset = offset,
-        .numVerts = numVerts + moreVerts,
-        .cullFace = false,
-        .drawMode = DRAW_MODE_LINES
-    };
+    GLBatchDrawCmd drawCmd
+        = { .offset = offset, .numVerts = numVerts + moreVerts, .cullFace = false, .drawMode = DRAW_MODE_LINES };
 
     return drawCmd;
 }
 
-void GLRender::RenderBegin(void)
-{
+void GLRender::RenderBegin(void) {
     // Make sure the screenspace 2d FBO is being cleared.
     m_2dFBO->Bind();
     glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
@@ -667,65 +659,61 @@ void GLRender::End3D(void) {
     m_3dFBO->Unbind(); // Set state back to GL default FBO.
 }
 
-void GLRender::ExecuteDrawCmds(std::vector<GLBatchDrawCmd>& drawCmds, GeometryType geomType)
-{
-    uint32_t prevDrawMode = GL_FILL;
+void GLRender::ExecuteDrawCmds(std::vector<GLBatchDrawCmd>& drawCmds, GeometryType geomType) {
+    uint32_t prevDrawMode  = GL_FILL;
     uint32_t primitiveType = GL_TRIANGLES;
-    for (int i = 0; i < drawCmds.size(); i++) {
+    for ( int i = 0; i < drawCmds.size(); i++ ) {
 
-        GLBatchDrawCmd drawCmd = drawCmds[i];
+        GLBatchDrawCmd drawCmd = drawCmds[ i ];
 
-        if (!drawCmd.cullFace) {
+        if ( !drawCmd.cullFace ) {
             glDisable(GL_CULL_FACE);
-        }
-        else {
+        } else {
             glEnable(GL_CULL_FACE);
         }
 
-        if (prevDrawMode != drawCmd.drawMode) {
-            if (drawCmd.drawMode == DRAW_MODE_WIREFRAME) {
+        if ( prevDrawMode != drawCmd.drawMode ) {
+            if ( drawCmd.drawMode == DRAW_MODE_WIREFRAME ) {
                 glLineWidth(1.0f);
                 glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
                 m_ImPrimitivesShader->SetShaderSettingBits(SHADER_LINEMODE);
-                prevDrawMode = GL_LINE;
+                prevDrawMode  = GL_LINE;
                 primitiveType = GL_TRIANGLES;
-            }
-            else if (drawCmd.drawMode == DRAW_MODE_LINES) {
+            } else if ( drawCmd.drawMode == DRAW_MODE_LINES ) {
                 glLineWidth(5.0f);
                 glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
                 m_ImPrimitivesShader->SetShaderSettingBits(SHADER_LINEMODE);
-                prevDrawMode = GL_FILL;
+                prevDrawMode  = GL_FILL;
                 primitiveType = GL_LINES;
-            }
-            else { // DRAW_MODE_SOLID
+            } else { // DRAW_MODE_SOLID
                 glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
-                prevDrawMode = GL_FILL;
+                prevDrawMode  = GL_FILL;
                 primitiveType = GL_TRIANGLES;
             }
         }
 
-        if (geomType == GEOM_TYPE_VERTEX_ONLY) {
+        if ( geomType == GEOM_TYPE_VERTEX_ONLY ) {
             glDrawArrays(primitiveType, drawCmd.offset, drawCmd.numVerts);
-        }
-        else if (geomType == GEOM_TYPE_INDEXED) {
+        } else if ( geomType == GEOM_TYPE_INDEXED ) {
             uint32_t indexBufferUSOffset = drawCmd.indexOffset * sizeof(uint16_t);
-            glDrawElementsBaseVertex(primitiveType, drawCmd.numIndices, GL_UNSIGNED_SHORT,
-                (GLvoid*)(drawCmd.indexOffset * sizeof(uint16_t)), drawCmd.offset);
+            glDrawElementsBaseVertex(primitiveType,
+                                     drawCmd.numIndices,
+                                     GL_UNSIGNED_SHORT,
+                                     (GLvoid*)(drawCmd.indexOffset * sizeof(uint16_t)),
+                                     drawCmd.offset);
         }
 
         m_ImPrimitivesShader->ResetShaderSettingBits(SHADER_LINEMODE);
     }
 }
 
-void GLRender::Render(Camera* camera,
-                      HKD_Model** models, uint32_t numModels,
-                      HKD_Model** brushModels, uint32_t numBrushModels)
-{
+void GLRender::Render(
+    Camera* camera, HKD_Model** models, uint32_t numModels, HKD_Model** brushModels, uint32_t numBrushModels) {
     // Camera and render settings
 
     static uint32_t drawWireframe = 0;
 
-    if (KeyWentDown(SDLK_r)) { // WARNING: TAB key also triggers slider-values in ImGui Window.
+    if ( KeyWentDown(SDLK_r) ) { // WARNING: TAB key also triggers slider-values in ImGui Window.
         drawWireframe ^= 1;
     }
 
@@ -740,7 +728,8 @@ void GLRender::Render(Camera* camera,
 
     glm::mat4 view = camera->ViewMatrix();
     // TODO: Global Setting for perspective values
-    glm::mat4 proj = glm::perspective(glm::radians(45.0f), (float)m_WindowWidth / (float)m_WindowHeight, 0.1f, 10000.0f);
+    glm::mat4 proj
+        = glm::perspective(glm::radians(45.0f), (float)m_WindowWidth / (float)m_WindowHeight, 0.1f, 10000.0f);
 
     // Draw immediate mode primitives
 
@@ -773,10 +762,10 @@ void GLRender::Render(Camera* camera,
     m_WorldShader->Activate();
     m_WorldShader->SetViewProjMatrices(view, proj);
 
-    for (auto const& [ texHandle, drawCmd ] : m_TexHandleToWorldDrawCmd) {
+    for ( auto const& [ texHandle, drawCmd ] : m_TexHandleToWorldDrawCmd ) {
         std::vector<GLBatchDrawCmd> drawCmds{ drawCmd };
-        glBindTexture( GL_TEXTURE_2D, texHandle );
-        ExecuteDrawCmds( drawCmds, GEOM_TYPE_VERTEX_ONLY );
+        glBindTexture(GL_TEXTURE_2D, texHandle);
+        ExecuteDrawCmds(drawCmds, GEOM_TYPE_VERTEX_ONLY);
     }
 
     /*for (auto const& [ texHandle, batch ] : m_TexHandleToWorldBatch) {*/
@@ -790,15 +779,15 @@ void GLRender::Render(Camera* camera,
     m_BrushBatch->Bind();
     m_BrushShader->Activate();
     m_BrushShader->SetViewProjMatrices(view, proj);
-    for (int i = 0; i < numBrushModels; i++) {
-        GLModel model = m_Models[ brushModels[i]->gpuModelHandle ];
-        glm::mat4 modelMatrix = CreateModelMatrix( brushModels[i] );
-        m_BrushShader->SetVec3( "position", brushModels[i]->position );
+    for ( int i = 0; i < numBrushModels; i++ ) {
+        GLModel   model       = m_Models[ brushModels[ i ]->gpuModelHandle ];
+        glm::mat4 modelMatrix = CreateModelMatrix(brushModels[ i ]);
+        m_BrushShader->SetVec3("position", brushModels[ i ]->position);
 
-        for (int j = 0; j < model.meshes.size(); j++) {
-            GLMesh* mesh = &model.meshes[j];
+        for ( int j = 0; j < model.meshes.size(); j++ ) {
+            GLMesh* mesh = &model.meshes[ j ];
             glBindTexture(GL_TEXTURE_2D, mesh->texture->m_gl_Handle);
-            glDrawArrays(GL_TRIANGLES, 3*mesh->triOffset, 3 * mesh->triCount);
+            glDrawArrays(GL_TRIANGLES, 3 * mesh->triOffset, 3 * mesh->triCount);
         }
     }
 
@@ -807,37 +796,34 @@ void GLRender::Render(Camera* camera,
     m_ModelBatch->Bind();
     m_ModelShader->Activate();
     m_ModelShader->SetViewProjMatrices(view, proj);
-    if (drawWireframe) {
+    if ( drawWireframe ) {
         m_ModelShader->SetShaderSettingBits(SHADER_WIREFRAME_ON_MESH);
-    }
-    else {
+    } else {
         m_ModelShader->ResetShaderSettingBits(SHADER_WIREFRAME_ON_MESH);
     }
-    for (int i = 0; i < numModels; i++) {
+    for ( int i = 0; i < numModels; i++ ) {
 
-        GLModel model = m_Models[ models[i]->gpuModelHandle ];
+        GLModel model = m_Models[ models[ i ]->gpuModelHandle ];
 
-        if ( models[i]->numJoints > 0 ) {
+        if ( models[ i ]->numJoints > 0 ) {
             m_ModelShader->SetShaderSettingBits(SHADER_ANIMATED);
-            m_ModelShader->SetMatrixPalette( &models[i]->palette[0], models[i]->numJoints );
-        }
-        else {
+            m_ModelShader->SetMatrixPalette(&models[ i ]->palette[ 0 ], models[ i ]->numJoints);
+        } else {
             m_ModelShader->ResetShaderSettingBits(SHADER_ANIMATED);
         }
 
-        glm::mat4 modelMatrix = CreateModelMatrix( models[i] );
+        glm::mat4 modelMatrix = CreateModelMatrix(models[ i ]);
         m_ModelShader->SetMat4("model", modelMatrix);
 
-        for (int j = 0; j < model.meshes.size(); j++) {
-            GLMesh* mesh = &model.meshes[j];
-            if (!mesh->texture->m_Filename.empty()) { // TODO: Checking string of empty is not great.
+        for ( int j = 0; j < model.meshes.size(); j++ ) {
+            GLMesh* mesh = &model.meshes[ j ];
+            if ( !mesh->texture->m_Filename.empty() ) { // TODO: Checking string of empty is not great.
                 m_ModelShader->SetShaderSettingBits(SHADER_IS_TEXTURED);
                 glBindTexture(GL_TEXTURE_2D, mesh->texture->m_gl_Handle);
-            }
-            else {
+            } else {
                 m_ModelShader->ResetShaderSettingBits(SHADER_IS_TEXTURED);
             }
-            glDrawArrays(GL_TRIANGLES, 3*mesh->triOffset, 3 * mesh->triCount);
+            glDrawArrays(GL_TRIANGLES, 3 * mesh->triOffset, 3 * mesh->triCount);
         }
     }
     m_ModelShader->ResetShaderSettingBits(SHADER_ANIMATED);
@@ -869,18 +855,14 @@ void GLRender::Begin2D() {
 
     glViewport(0, 0, m_2dFBO->m_Width, m_2dFBO->m_Height);
 
-
-    glm::mat4 ortho = glm::ortho(0.0f, (float)m_2dFBO->m_Width,
-                                 (float)m_2dFBO->m_Height, 0.0f,
-                                 -1.0f, 1.0f);
+    glm::mat4 ortho = glm::ortho(0.0f, (float)m_2dFBO->m_Width, (float)m_2dFBO->m_Height, 0.0f, -1.0f, 1.0f);
     m_FontShader->Activate();
-    m_FontShader->SetViewProjMatrices( glm::mat4(1.0f), ortho );
+    m_FontShader->SetViewProjMatrices(glm::mat4(1.0f), ortho);
     m_ShapesShader->Activate();
-    m_ShapesShader->SetViewProjMatrices( glm::mat4(1.0f), ortho );
+    m_ShapesShader->SetViewProjMatrices(glm::mat4(1.0f), ortho);
 }
 
 void GLRender::End2D() {
-
 
     m_2dFBO->Unbind();
     //m_FontBatch->Unbind();
@@ -903,8 +885,8 @@ void GLRender::SetFont(CFont* font, glm::vec4 color) {
         glm::vec4(0.0f) // NOTE: unused at the moment.
     };
 
-    glBindBuffer( GL_UNIFORM_BUFFER, m_FontShader->m_FontUBO );
-    glBufferSubData( GL_UNIFORM_BUFFER, 0, sizeof(FontUB), (void*)&fontShaderData );
+    glBindBuffer(GL_UNIFORM_BUFFER, m_FontShader->m_FontUBO);
+    glBufferSubData(GL_UNIFORM_BUFFER, 0, sizeof(FontUB), (void*)&fontShaderData);
     glBindBuffer(GL_UNIFORM_BUFFER, 0);
 
     m_CurrentFont = font;
@@ -918,8 +900,8 @@ void GLRender::SetShapeColor(glm::vec4 color) {
         glm::vec4(0.0f) // NOTE: unused at the moment.
     };
 
-    glBindBuffer( GL_UNIFORM_BUFFER, m_ShapesShader->m_ShapesUBO );
-    glBufferSubData( GL_UNIFORM_BUFFER, 0, sizeof(ShapesUB), (void*)&shapesShaderData );
+    glBindBuffer(GL_UNIFORM_BUFFER, m_ShapesShader->m_ShapesUBO);
+    glBufferSubData(GL_UNIFORM_BUFFER, 0, sizeof(ShapesUB), (void*)&shapesShaderData);
     glBindBuffer(GL_UNIFORM_BUFFER, 0);
 }
 
@@ -927,10 +909,7 @@ void GLRender::FlushFonts() {
     m_FontBatch->Bind();
     m_FontShader->Activate();
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    glDrawElementsBaseVertex(GL_TRIANGLES,
-                             m_FontBatch->IndexCount(),
-                             GL_UNSIGNED_SHORT,
-                             (GLvoid*)0, 0);
+    glDrawElementsBaseVertex(GL_TRIANGLES, m_FontBatch->IndexCount(), GL_UNSIGNED_SHORT, (GLvoid*)0, 0);
 
     m_FontBatch->Reset();
 }
@@ -938,24 +917,18 @@ void GLRender::FlushFonts() {
 void GLRender::FlushShapes() {
     m_ShapesBatch->Bind();
     m_ShapesShader->Activate();
-    glBlendFunc( GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA );
-    glDrawElementsBaseVertex(GL_TRIANGLES,
-                             m_ShapesBatch->IndexCount(),
-                             GL_UNSIGNED_SHORT,
-                             (GLvoid*)0, 0);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glDrawElementsBaseVertex(GL_TRIANGLES, m_ShapesBatch->IndexCount(), GL_UNSIGNED_SHORT, (GLvoid*)0, 0);
 
     m_ShapesBatch->Reset();
 }
 
-void GLRender::R_DrawText(const std::string& text,
-                        float x, float y,
-                        ScreenSpaceCoordMode coordMode) {
+void GLRender::R_DrawText(const std::string& text, float x, float y, ScreenSpaceCoordMode coordMode) {
 
     // TODO: (Michael): Make sure that the correct shader is active.
 
-
     float xOffset = WINDOW_WIDTH * x;
-    float yOffset = WINDOW_HEIGHT* y;
+    float yOffset = WINDOW_HEIGHT * y;
 
     if ( coordMode == COORD_MODE_ABS ) {
         xOffset = x;
@@ -965,24 +938,22 @@ void GLRender::R_DrawText(const std::string& text,
     FaceQuad fq{}; // = CreateFaceQuadFromVerts(vertices);
 
     // go through each character in text and lookup the correct UV.
-    int out_OffsetIndices = 0; // TODO: Not needed here!
+    int out_OffsetIndices  = 0; // TODO: Not needed here!
     int out_OffsetVertices = 0; // TODO: Not needed here!
 
     // TODO: (Michael): Make indices uint32_t.
-    uint16_t iOffset = (uint16_t)m_FontBatch->m_LastIndex;
+    uint16_t iOffset   = (uint16_t)m_FontBatch->m_LastIndex;
     uint16_t lastIndex = iOffset;
 
-    const char* c = text.c_str();
-    int i = 0;
-    float ascender = (float)m_CurrentFont->m_Ascender;
-    float tallestGlyph = ascender;
+    const char* c            = text.c_str();
+    int         i            = 0;
+    float       ascender     = (float)m_CurrentFont->m_Ascender;
+    float       tallestGlyph = ascender;
     while ( *c != '\0' ) {
         if ( *c >= FIRST_CODE_POINT && *c < LAST_CODE_POINT ) {
 
-            uint16_t indices[6] = {
-                iOffset + 0 + i*4, iOffset + 1 + i*4, iOffset + 2 + i*4,
-                iOffset + 2 + i*4, iOffset + 3 + i*4, iOffset + 0 + i*4
-            };
+            uint16_t           indices[ 6 ] = { iOffset + 0 + i * 4, iOffset + 1 + i * 4, iOffset + 2 + i * 4,
+                                                iOffset + 2 + i * 4, iOffset + 3 + i * 4, iOffset + 0 + i * 4 };
             stbtt_aligned_quad q;
 
             // Newbe API
@@ -990,11 +961,13 @@ void GLRender::R_DrawText(const std::string& text,
 
             // More advanced API
             stbtt_GetPackedQuad(m_CurrentFont->m_PackedCharData,
-                                FONT_TEX_SIZE, FONT_TEX_SIZE,
-                                *c - FIRST_CODE_POINT,             // character to display
-                                &xOffset, &yOffset,
+                                FONT_TEX_SIZE,
+                                FONT_TEX_SIZE,
+                                *c - FIRST_CODE_POINT, // character to display
+                                &xOffset,
+                                &yOffset,
                                 // pointers to current position in screen pixel space
-                                &q,      // output: quad to draw
+                                &q, // output: quad to draw
                                 1);
 
             float x0 = q.x0;
@@ -1008,16 +981,14 @@ void GLRender::R_DrawText(const std::string& text,
             fq.d.pos = { x1, y0 + tallestGlyph, 0.0f };
             fq.a.pos = { x1, y1 + tallestGlyph, 0.0f };
             fq.b.pos = { x0, y1 + tallestGlyph, 0.0f };
-            fq.a.uv = { q.s1, q.t1 };
-            fq.b.uv = { q.s0, q.t1 };
-            fq.c.uv = { q.s0, q.t0 };
-            fq.d.uv = { q.s1, q.t0 };
-            m_FontBatch->Add(fq.vertices, 4,
-                                      indices, 6,
-                                      &out_OffsetVertices, &out_OffsetIndices,
-                                      false, DRAW_MODE_SOLID);
+            fq.a.uv  = { q.s1, q.t1 };
+            fq.b.uv  = { q.s0, q.t1 };
+            fq.c.uv  = { q.s0, q.t0 };
+            fq.d.uv  = { q.s1, q.t0 };
+            m_FontBatch->Add(
+                fq.vertices, 4, indices, 6, &out_OffsetVertices, &out_OffsetIndices, false, DRAW_MODE_SOLID);
 
-            lastIndex = iOffset + 3 + i*4;
+            lastIndex = iOffset + 3 + i * 4;
 
             i++;
         }
@@ -1034,7 +1005,7 @@ void GLRender::R_DrawText(const std::string& text,
 void GLRender::DrawBox(float x, float y, float width, float height, ScreenSpaceCoordMode coordMode) {
 
     float x0 = WINDOW_WIDTH * x;
-    float y0 = WINDOW_HEIGHT* y;
+    float y0 = WINDOW_HEIGHT * y;
     float x1 = WINDOW_WIDTH * (x + width);
     float y1 = WINDOW_HEIGHT * (y + height);
 
@@ -1045,29 +1016,21 @@ void GLRender::DrawBox(float x, float y, float width, float height, ScreenSpaceC
         y1 = y + height;
     }
 
-    Vertex verts[4] = {
-        { glm::vec3(x0, y0, 0.0f) },
-        { glm::vec3(x0, y1, 0.0f) },
-        { glm::vec3(x1, y1, 0.0f) },
-        { glm::vec3(x1, y0, 0.0f) }
-    };
-    FaceQuad fq = CreateFaceQuadFromVerts( verts );
+    Vertex   verts[ 4 ] = { { glm::vec3(x0, y0, 0.0f) },
+                            { glm::vec3(x0, y1, 0.0f) },
+                            { glm::vec3(x1, y1, 0.0f) },
+                            { glm::vec3(x1, y0, 0.0f) } };
+    FaceQuad fq         = CreateFaceQuadFromVerts(verts);
 
-    uint16_t iOffset = (uint16_t)m_ShapesBatch->m_LastIndex;
-    uint16_t indices[6] = {
-        iOffset + 0, iOffset + 1, iOffset + 2,
-        iOffset + 2, iOffset + 3, iOffset + 0
-    };
+    uint16_t iOffset      = (uint16_t)m_ShapesBatch->m_LastIndex;
+    uint16_t indices[ 6 ] = { iOffset + 0, iOffset + 1, iOffset + 2, iOffset + 2, iOffset + 3, iOffset + 0 };
 
     // NOTE: (Michael): The batch interface is going to change once we have
     // the first prototype going. So no need to fix those inconvenciences
     // of unused (and unwanted) out_* variables for now!
-    int out_OffsetIndices = 0; // TODO: Not needed here!
+    int out_OffsetIndices  = 0; // TODO: Not needed here!
     int out_OffsetVertices = 0; // TODO: Not needed here!
-    m_ShapesBatch->Add(fq.vertices, 4,
-                              indices, 6,
-                              &out_OffsetVertices, &out_OffsetIndices,
-                              false, DRAW_MODE_SOLID);
+    m_ShapesBatch->Add(fq.vertices, 4, indices, 6, &out_OffsetVertices, &out_OffsetIndices, false, DRAW_MODE_SOLID);
 
     m_ShapesBatch->m_LastIndex += 4;
 
@@ -1081,33 +1044,27 @@ void GLRender::DrawBox(float x, float y, float width, float height, ScreenSpaceC
     FlushShapes();
 }
 
-void GLRender::RenderColliders(Camera* camera, HKD_Model** models, uint32_t numModels)
-{
+void GLRender::RenderColliders(Camera* camera, HKD_Model** models, uint32_t numModels) {
     glm::mat4 view = camera->ViewMatrix();
     // TODO: Global Setting for perspective values
-    glm::mat4 proj = glm::perspective(
-        glm::radians(45.0f),
-        (float)m_WindowWidth / (float)m_WindowHeight,
-        0.1f, 10000.0f);
+    glm::mat4 proj
+        = glm::perspective(glm::radians(45.0f), (float)m_WindowWidth / (float)m_WindowHeight, 0.1f, 10000.0f);
 
     m_ColliderShader->Activate();
     m_ColliderShader->SetViewProjMatrices(view, proj);
 
     m_ColliderBatch->Bind();
-    for (int i = 0; i < numModels; i++) {
-        HKD_Model* model = models[i];
+    for ( int i = 0; i < numModels; i++ ) {
+        HKD_Model* model = models[ i ];
         m_ColliderShader->SetVec4("uDebugColor", model->debugColor);
-        EllipsoidCollider ec = model->ellipsoidColliders[model->currentAnimIdx];
-        glm::vec3 scale = glm::vec3(
-            ec.radiusA,
-            ec.radiusA,
-            ec.radiusB);
+        EllipsoidCollider ec    = model->ellipsoidColliders[ model->currentAnimIdx ];
+        glm::vec3         scale = glm::vec3(ec.radiusA, ec.radiusA, ec.radiusB);
 
         glm::mat4 T = glm::translate(glm::mat4(1.0f), ec.center);
         glm::mat4 S = glm::scale(glm::mat4(1.0f), scale);
         glm::mat4 M = T * S;
         m_ColliderShader->SetMat4("model", M);
-        std::vector<GLBatchDrawCmd> drawCmds = {m_EllipsoidColliderDrawCmd};
+        std::vector<GLBatchDrawCmd> drawCmds = { m_EllipsoidColliderDrawCmd };
         //glDrawArrays(GL_TRIANGLES, m_EllipsoidColliderDrawCmd.offset, m_EllipsoidColliderDrawCmd.numVerts);
         ExecuteDrawCmds(drawCmds, GEOM_TYPE_VERTEX_ONLY);
         // glDrawArrays(GL_LINES,
@@ -1117,20 +1074,23 @@ void GLRender::RenderColliders(Camera* camera, HKD_Model** models, uint32_t numM
 }
 
 void GLRender::RenderConsole(Console* console, CFont* font) {
-    if (!console->m_isActive) return;
+    if ( !console->m_isActive ) return;
 
-    const float relHeight = scr_consize.value;
-    const float height = m_WindowHeight * relHeight;
+    const float relHeight   = scr_consize.value;
+    const float height      = m_WindowHeight * relHeight;
     const float borderWidth = 2.0f;
-    const float textMargin = 10.0f;
-    const float lineHeight = font->m_Size + textMargin; // TODO: possibly derive from font *line gap* metric in the future?
-    const float charWidth = font->m_Size * 0.602f; // assumes mono-space font  // FIXME: this is just an estimation, should be derived from the font!
+    const float textMargin  = 10.0f;
+    const float lineHeight
+        = font->m_Size + textMargin; // TODO: possibly derive from font *line gap* metric in the future?
+    const float charWidth
+        = font->m_Size
+          * 0.602f; // assumes mono-space font  // FIXME: this is just an estimation, should be derived from the font!
 
-    const float inputY = height - font->m_Size - textMargin;
-    float logY = inputY - textMargin * 2 - font->m_Size;
-    const int maxLines = floor(logY / lineHeight) + 1;
-    const int maxChars = floor((m_WindowWidth - 2 * textMargin) / charWidth);
-    const bool isScrollable = console->m_lineBuffer.Size() > maxLines;
+    const float inputY       = height - font->m_Size - textMargin;
+    float       logY         = inputY - textMargin * 2 - font->m_Size;
+    const int   maxLines     = floor(logY / lineHeight) + 1;
+    const int   maxChars     = floor((m_WindowWidth - 2 * textMargin) / charWidth);
+    const bool  isScrollable = console->m_lineBuffer.Size() > maxLines;
 
     Begin2D();
     m_ConsoleFBO->Bind();
@@ -1146,49 +1106,49 @@ void GLRender::RenderConsole(Console* console, CFont* font) {
 
     // draw input
     SetFont(font, glm::vec4(1.0f));
-    std::string prefix = "> ";
-    int maxInputChars = maxChars - prefix.length();
-    int textOffset = ((console->CursorPos() - 1) / maxInputChars) * maxInputChars; // integer division
-    if (console->CurrentInput().length() > maxInputChars) prefix = "<>"; // indicate line overflow
+    std::string prefix        = "> ";
+    int         maxInputChars = maxChars - prefix.length();
+    int         textOffset    = ((console->CursorPos() - 1) / maxInputChars) * maxInputChars; // integer division
+    if ( console->CurrentInput().length() > maxInputChars ) prefix = "<>";                    // indicate line overflow
     std::string inputText = prefix + console->CurrentInput().substr(textOffset, maxInputChars);
     R_DrawText(inputText, textMargin, inputY, COORD_MODE_ABS);
 
     // draw cursor
-    if (console->m_blinkTimer < 500.0) {
+    if ( console->m_blinkTimer < 500.0 ) {
         float cursorX = textMargin + (console->CursorPos() - textOffset + prefix.length()) * charWidth;
         SetShapeColor(glm::vec4(0.8f, 0.8f, 0.8f, 1.0f));
         DrawBox(cursorX - 2.5f, inputY - 3.0f, 5.0f, font->m_Size + 4.0f, COORD_MODE_ABS);
-    } else if (console->m_blinkTimer > 1000.0) {
+    } else if ( console->m_blinkTimer > 1000.0 ) {
         console->m_blinkTimer = 0;
     }
 
     // draw bottom scroll indicator
-    if (isScrollable && console->ScrollPos() != 0) {
+    if ( isScrollable && console->ScrollPos() != 0 ) {
         R_DrawText(std::string(maxChars, '^'), textMargin, logY + lineHeight * 0.7f, COORD_MODE_ABS);
     }
 
     // draw log lines
-    for (int i = 0; i < maxLines; i++) {
-        int lineOffset = isScrollable ? console->ScrollPos() + i : i;
+    for ( int i = 0; i < maxLines; i++ ) {
+        int         lineOffset = isScrollable ? console->ScrollPos() + i : i;
         std::string line;
-        if (!console->m_lineBuffer.Get(lineOffset, &line)) {
-            if (isScrollable) {
-                std::string msg = " END OF LOG ";
-                int chars = (maxChars - msg.length()) / 2;
-                msg = std::string(chars, '-') + msg;
+        if ( !console->m_lineBuffer.Get(lineOffset, &line) ) {
+            if ( isScrollable ) {
+                std::string msg   = " END OF LOG ";
+                int         chars = (maxChars - msg.length()) / 2;
+                msg               = std::string(chars, '-') + msg;
                 R_DrawText(msg + std::string(maxChars - msg.length(), '-'), textMargin, logY, COORD_MODE_ABS);
             }
             break;
         }
-        if (scr_conwraplines.value && line.length() > maxChars) {
+        if ( scr_conwraplines.value && line.length() > maxChars ) {
             std::vector<std::string> segments;
-            for (int offset = 0; offset < line.length(); offset += maxChars) {
+            for ( int offset = 0; offset < line.length(); offset += maxChars ) {
                 segments.push_back(line.substr(offset, maxChars));
             }
-            for (int j = segments.size() - 1; j >= 0; j--) {
-                R_DrawText(segments[j], textMargin, logY, COORD_MODE_ABS);
+            for ( int j = segments.size() - 1; j >= 0; j-- ) {
+                R_DrawText(segments[ j ], textMargin, logY, COORD_MODE_ABS);
                 logY -= lineHeight;
-                if (++i == maxLines) break;
+                if ( ++i == maxLines ) break;
             }
         } else {
             R_DrawText(line, textMargin, logY, COORD_MODE_ABS);
@@ -1200,8 +1160,7 @@ void GLRender::RenderConsole(Console* console, CFont* font) {
     End2D();
 }
 
-void GLRender::RenderEnd(void)
-{
+void GLRender::RenderEnd(void) {
     // At this point the GL default FBO must be active!
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
 
@@ -1222,34 +1181,31 @@ void GLRender::RenderEnd(void)
     // Composite all the FBOs together
     m_CompositeShader->Activate();
 
-    GLuint texLoc3d = glGetUniformLocation(m_CompositeShader->Program(),
-                                           "main3dSceneTexture");
+    GLuint texLoc3d = glGetUniformLocation(m_CompositeShader->Program(), "main3dSceneTexture");
 
-    GLuint texLoc2d = glGetUniformLocation(m_CompositeShader->Program(),
-                                           "screenspace2dTexture");
+    GLuint texLoc2d = glGetUniformLocation(m_CompositeShader->Program(), "screenspace2dTexture");
 
-    GLuint texLocConsole = glGetUniformLocation(m_CompositeShader->Program(),
-                                                "consoleTexture");
+    GLuint texLocConsole = glGetUniformLocation(m_CompositeShader->Program(), "consoleTexture");
 
     glUniform1i(texLoc3d, 0);
     // Bind the 3d scene FBO and draw it.
     CglRenderTexture main3dSceneTexture = m_3dFBO->m_ColorTexture;
-    glActiveTexture( GL_TEXTURE0 );
-    glBindTexture( GL_TEXTURE_2D, main3dSceneTexture.m_gl_Handle );
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, main3dSceneTexture.m_gl_Handle);
 
     glUniform1i(texLoc2d, 1);
     // Bind the 2d screenspace FBO texture and draw on top.
     CglRenderTexture screenSpace2dTexture = m_2dFBO->m_ColorTexture;
-    glActiveTexture( GL_TEXTURE1 );
-    glBindTexture( GL_TEXTURE_2D, screenSpace2dTexture.m_gl_Handle );
+    glActiveTexture(GL_TEXTURE1);
+    glBindTexture(GL_TEXTURE_2D, screenSpace2dTexture.m_gl_Handle);
 
     glUniform1i(texLocConsole, 2);
     // Bind the 2d console FBO texture and draw on top.
     CglRenderTexture consoleTexture = m_ConsoleFBO->m_ColorTexture;
-    glActiveTexture( GL_TEXTURE2 );
-    glBindTexture( GL_TEXTURE_2D, consoleTexture.m_gl_Handle );
+    glActiveTexture(GL_TEXTURE2);
+    glBindTexture(GL_TEXTURE_2D, consoleTexture.m_gl_Handle);
 
-    glDrawArrays( GL_TRIANGLES, 0, 6 );
+    glDrawArrays(GL_TRIANGLES, 0, 6);
 
     // FIX: This is the reason why textures in OpenGL suck!!! If we are
     // not careful, and *don't* set the state back, then the following
@@ -1259,8 +1215,8 @@ void GLRender::RenderEnd(void)
     // (I just did!). Luckily, we can use bindless
     // textures in OpenGL which we *definitely* want to use in a
     // facelift of the renderer.
-    glBindTexture( GL_TEXTURE_2D, 0 );
-    glActiveTexture( GL_TEXTURE0 );
+    glBindTexture(GL_TEXTURE_2D, 0);
+    glActiveTexture(GL_TEXTURE0);
 
     // Render ImGui Elements ontop of everything.
     ImGui::Render();
@@ -1276,58 +1232,40 @@ void GLRender::RenderEnd(void)
     m_PrimitiveIndexdDrawCmds.clear();
 }
 
-void GLRender::InitShaders()
-{
+void GLRender::InitShaders() {
     Shader::InitGlobalBuffers();
 
     // Models
 
     m_ModelShader = new Shader();
-    if ( !m_ModelShader->Load(
-        "shaders/entities.vert",
-        "shaders/entities.frag",
-        SHADER_FEATURE_MODEL_ANIMATION_BIT
-    )) {
+    if ( !m_ModelShader->Load("shaders/entities.vert", "shaders/entities.frag", SHADER_FEATURE_MODEL_ANIMATION_BIT) ) {
         printf("Problems initializing model shaders!\n");
     }
 
     // Immediate mode Primitives: Lines, Tris, ...
 
     m_ImPrimitivesShader = new Shader();
-    if ( !m_ImPrimitivesShader->Load(
-        "shaders/primitives.vert",
-        "shaders/primitives.frag"
-    )) {
+    if ( !m_ImPrimitivesShader->Load("shaders/primitives.vert", "shaders/primitives.frag") ) {
         printf("Problems initializing primitives shader!\n");
     }
 
     // Colliders (for now: Ellipsoids, but can also be AABBs, etc.)
 
     m_ColliderShader = new Shader();
-    if ( !m_ColliderShader->Load(
-        "shaders/colliders.vert",
-        "shaders/colliders.frag"
-        )) {
+    if ( !m_ColliderShader->Load("shaders/colliders.vert", "shaders/colliders.frag") ) {
         printf("Problems initializin colliders shader!\n");
     }
 
     // TODO: Just to test if shaders overwrite data from each other. Delete later!
     Shader* foo = new Shader();
-    if ( !foo->Load(
-        "shaders/entities.vert",
-        "shaders/entities.frag",
-        SHADER_FEATURE_MODEL_ANIMATION_BIT
-    )) {
+    if ( !foo->Load("shaders/entities.vert", "shaders/entities.frag", SHADER_FEATURE_MODEL_ANIMATION_BIT) ) {
         printf("Problems initializing model shaders!\n");
     }
 
     // 2D Screenspace: UI, Console, etc.
 
     m_FontShader = new Shader();
-    if ( !m_FontShader->Load(
-        "shaders/font.vert",
-        "shaders/font.frag"
-        )) {
+    if ( !m_FontShader->Load("shaders/font.vert", "shaders/font.frag") ) {
         printf("Problems initializing font shader!\n");
     }
     // TODO: We could think about actually creating a subclass
@@ -1339,40 +1277,27 @@ void GLRender::InitShaders()
     m_FontShader->InitializeFontUniforms();
 
     m_ShapesShader = new Shader();
-    if ( !m_ShapesShader->Load(
-        "shaders/shapes2d.vert",
-        "shaders/shapes2d.frag"
-    )) {
+    if ( !m_ShapesShader->Load("shaders/shapes2d.vert", "shaders/shapes2d.frag") ) {
         printf("Problems initializing shapes2d shader!\n");
     }
     m_ShapesShader->InitializeShapesUniforms();
 
     m_CompositeShader = new Shader();
-    if ( !m_CompositeShader->Load(
-        "shaders/composite.vert",
-        "shaders/composite.frag"
-    )) {
+    if ( !m_CompositeShader->Load("shaders/composite.vert", "shaders/composite.frag") ) {
         printf("Problems initializing composite shader!\n");
     }
 
     m_WorldShader = new Shader();
-    if ( !m_WorldShader->Load(
-        "shaders/world.vert",
-        "shaders/world.frag"
-    )) {
+    if ( !m_WorldShader->Load("shaders/world.vert", "shaders/world.frag") ) {
         printf("Problems initializing world shader!\n");
     }
 
     m_BrushShader = new Shader();
-    if ( !m_BrushShader->Load(
-        "shaders/brush.vert",
-        "shaders/brush.frag"
-    )) {
+    if ( !m_BrushShader->Load("shaders/brush.vert", "shaders/brush.frag") ) {
         printf("Problems initializing brush shader!\n");
     }
 }
 
-void GLRender::SetWindowTitle(char* windowTitle)
-{
+void GLRender::SetWindowTitle(char* windowTitle) {
     SDL_SetWindowTitle(m_Window, windowTitle);
 }

--- a/r_gl.h
+++ b/r_gl.h
@@ -8,126 +8,135 @@
 #include <SDL.h>
 #include <glad/glad.h>
 
-#include "r_common.h"
-#include "r_model.h"
-#include "r_gl_batch.h"
-#include "r_gl_shader.h"
-#include "r_gl_texture_mgr.h"
-#include "r_gl_texture.h"
-#include "r_gl_fbo.h"
-#include "camera.h"
 #include "Console/Console.h"
+#include "camera.h"
+#include "r_common.h"
+#include "r_gl_batch.h"
+#include "r_gl_fbo.h"
+#include "r_gl_shader.h"
+#include "r_gl_texture.h"
+#include "r_gl_texture_mgr.h"
+#include "r_model.h"
 
 struct GLMesh {
-	int			triOffset, triCount; // Offsets into VBO of tris
-	GLTexture*	texture;
+    int        triOffset, triCount; // Offsets into VBO of tris
+    GLTexture* texture;
 };
 
 // Models for entities (Players, Monsters, Pickup Items...)
 struct GLModel {
-	std::vector<GLMesh> meshes;
+    std::vector<GLMesh> meshes;
 };
 
 class GLRender : public IRender {
-public:
-	virtual bool Init(void)								override;
-	virtual void Shutdown(void)							override;
-	virtual int  RegisterModel(HKD_Model* model)		override;
-	virtual int  RegisterBrush(HKD_Model* model)        override;
-	virtual void RegisterFont(CFont* font) override;
-	virtual void RegisterWorld(CWorld* world) override;
-	virtual uint64_t RegisterTextureGetHandle(std::string name) override;
-	virtual void SetActiveCamera(Camera* camera) override;
-	virtual std::vector<ITexture*> ModelTextures(int gpuModelHandle)	override;
-	virtual std::vector<ITexture*> Textures(void)       override;
-	virtual void ImDrawTris(Tri* tris, uint32_t numTris, bool cullFace = true, DrawMode drawMode = DRAW_MODE_SOLID) override;
-	virtual void ImDrawTriPlanes(TriPlane* triPlanes, uint32_t numTriPlanes, bool cullFace = true, DrawMode drawMode = DRAW_MODE_SOLID) override;
-	virtual void ImDrawIndexed(Vertex* verts, uint32_t numVerts, uint16_t* indices, uint32_t numIndices, bool cullFace = true, DrawMode drawMode = DRAW_MODE_SOLID) override;
-	virtual void ImDrawVerts(Vertex* verts, uint32_t numVerts) override;
-	virtual void ImDrawLines(Vertex* verts, uint32_t numVerts, bool close = false) override;
-	virtual void ImDrawCircle(glm::vec3 center,float radius, glm::vec3 normal) override;
-	virtual void ImDrawSphere(glm::vec3 pos, float radius, glm::vec4 color = glm::vec4(1.0f, 0.0f, 0.0f, 1.0f)) override;
-	virtual void RenderBegin(void)						override;
-	virtual void Render(Camera* camera, 
-					 HKD_Model** models, uint32_t numModels,
-                     HKD_Model** brushModels, uint32_t numBrushModels) override;
-	virtual void RenderColliders(Camera* camera, HKD_Model** models, uint32_t numModels) override;
-	virtual void RenderConsole(Console* console, CFont* font) override;
-	virtual void Begin3D() override;
-	virtual void End3D()   override;
-	virtual void DrawWorldTris() override;
-	virtual void Begin2D() override;
-	virtual void End2D() override;
-	virtual void SetFont(CFont* font, glm::vec4 color = glm::vec4(1.0f)) override;
-	virtual void SetShapeColor(glm::vec4 color = glm::vec4(1.0f)) override;
-	virtual void R_DrawText(const std::string& text,
-				float x, float y, 
-				ScreenSpaceCoordMode coordMode = COORD_MODE_REL) override;
-	virtual void FlushFonts() override;
-	virtual void FlushShapes() override;
-	virtual void DrawBox(float x, float y, float width, float height,
-					  ScreenSpaceCoordMode coordMode = COORD_MODE_REL) override;
-	virtual void RenderEnd(void)						override;
-	virtual void SetWindowTitle(char* windowTitle) override;
+  public:
+    virtual bool                   Init(void) override;
+    virtual void                   Shutdown(void) override;
+    virtual int                    RegisterModel(HKD_Model* model) override;
+    virtual int                    RegisterBrush(HKD_Model* model) override;
+    virtual void                   RegisterFont(CFont* font) override;
+    virtual void                   RegisterWorld(CWorld* world) override;
+    virtual uint64_t               RegisterTextureGetHandle(std::string name) override;
+    virtual void                   SetActiveCamera(Camera* camera) override;
+    virtual std::vector<ITexture*> ModelTextures(int gpuModelHandle) override;
+    virtual std::vector<ITexture*> Textures(void) override;
+    virtual void
+    ImDrawTris(Tri* tris, uint32_t numTris, bool cullFace = true, DrawMode drawMode = DRAW_MODE_SOLID) override;
+    virtual void ImDrawTriPlanes(TriPlane* triPlanes,
+                                 uint32_t  numTriPlanes,
+                                 bool      cullFace = true,
+                                 DrawMode  drawMode = DRAW_MODE_SOLID) override;
+    virtual void ImDrawIndexed(Vertex*   verts,
+                               uint32_t  numVerts,
+                               uint16_t* indices,
+                               uint32_t  numIndices,
+                               bool      cullFace = true,
+                               DrawMode  drawMode = DRAW_MODE_SOLID) override;
+    virtual void ImDrawVerts(Vertex* verts, uint32_t numVerts) override;
+    virtual void ImDrawLines(Vertex* verts, uint32_t numVerts, bool close = false) override;
+    virtual void ImDrawCircle(glm::vec3 center, float radius, glm::vec3 normal) override;
+    virtual void
+    ImDrawSphere(glm::vec3 pos, float radius, glm::vec4 color = glm::vec4(1.0f, 0.0f, 0.0f, 1.0f)) override;
+    virtual void RenderBegin(void) override;
+    virtual void Render(Camera*     camera,
+                        HKD_Model** models,
+                        uint32_t    numModels,
+                        HKD_Model** brushModels,
+                        uint32_t    numBrushModels) override;
+    virtual void RenderColliders(Camera* camera, HKD_Model** models, uint32_t numModels) override;
+    virtual void RenderConsole(Console* console, CFont* font) override;
+    virtual void Begin3D() override;
+    virtual void End3D() override;
+    virtual void DrawWorldTris() override;
+    virtual void Begin2D() override;
+    virtual void End2D() override;
+    virtual void SetFont(CFont* font, glm::vec4 color = glm::vec4(1.0f)) override;
+    virtual void SetShapeColor(glm::vec4 color = glm::vec4(1.0f)) override;
+    virtual void
+    R_DrawText(const std::string& text, float x, float y, ScreenSpaceCoordMode coordMode = COORD_MODE_REL) override;
+    virtual void FlushFonts() override;
+    virtual void FlushShapes() override;
+    virtual void
+    DrawBox(float x, float y, float width, float height, ScreenSpaceCoordMode coordMode = COORD_MODE_REL) override;
+    virtual void RenderEnd(void) override;
+    virtual void SetWindowTitle(char* windowTitle) override;
 
-	void ExecuteDrawCmds(std::vector<GLBatchDrawCmd>& drawCmds, GeometryType geomType);
-	void InitShaders();
-	void RegisterColliderModels();
-	GLBatchDrawCmd AddLineToBatch(GLBatch* btach, Vertex* verts, uint32_t numVerts, bool close);
-	GLBatchDrawCmd AddTrisToBatch(GLBatch* batch, Tri* tris, uint32_t numTris, bool cullFace, DrawMode drawMode);
+    void           ExecuteDrawCmds(std::vector<GLBatchDrawCmd>& drawCmds, GeometryType geomType);
+    void           InitShaders();
+    void           RegisterColliderModels();
+    GLBatchDrawCmd AddLineToBatch(GLBatch* btach, Vertex* verts, uint32_t numVerts, bool close);
+    GLBatchDrawCmd AddTrisToBatch(GLBatch* batch, Tri* tris, uint32_t numTris, bool cullFace, DrawMode drawMode);
 
-private:	
-	SDL_Window*					m_Window;
-	SDL_GLContext				m_SDL_GL_Conext;
+  private:
+    SDL_Window*   m_Window;
+    SDL_GLContext m_SDL_GL_Conext;
 
-	GLTextureManager*			m_TextureManager;
+    GLTextureManager* m_TextureManager;
 
-	Camera*						m_ActiveCamera;
+    Camera* m_ActiveCamera;
 
-	// Draw world polygons based on their texture handle.
-	std::unordered_map<uint64_t, GLBatchDrawCmd> m_TexHandleToWorldDrawCmd;
-	GLBatch*					m_WorldBatch;
-	GLBatch*					m_BrushBatch; // World geometry from brush entities.
+    // Draw world polygons based on their texture handle.
+    std::unordered_map<uint64_t, GLBatchDrawCmd> m_TexHandleToWorldDrawCmd;
+    GLBatch*                                     m_WorldBatch;
+    GLBatch*                                     m_BrushBatch; // World geometry from brush entities.
 
-	GLBatch*					m_ModelBatch;
-	std::vector<GLBatchDrawCmd> m_ModelDrawCmds;
-	
-	GLBatch*					m_ImPrimitiveBatch;	
-	std::vector<GLBatchDrawCmd> m_PrimitiveDrawCmds;
+    GLBatch*                    m_ModelBatch;
+    std::vector<GLBatchDrawCmd> m_ModelDrawCmds;
 
-	GLBatch*					m_ImPrimitiveBatchIndexed;
-	std::vector<GLBatchDrawCmd>	m_PrimitiveIndexdDrawCmds;
+    GLBatch*                    m_ImPrimitiveBatch;
+    std::vector<GLBatchDrawCmd> m_PrimitiveDrawCmds;
 
-	GLBatch*					m_FontBatch;
-	GLBatch*					m_ShapesBatch;
-	
-	Shader*						m_ModelShader;
-	std::vector<GLModel>		m_Models;
+    GLBatch*                    m_ImPrimitiveBatchIndexed;
+    std::vector<GLBatchDrawCmd> m_PrimitiveIndexdDrawCmds;
 
-	Shader*                     m_WorldShader;
-	Shader*						m_BrushShader;
+    GLBatch* m_FontBatch;
+    GLBatch* m_ShapesBatch;
 
-	Shader*						m_ImPrimitivesShader;
+    Shader*              m_ModelShader;
+    std::vector<GLModel> m_Models;
 
-	Shader*						m_ColliderShader;
-	GLBatch*					m_ColliderBatch;
+    Shader* m_WorldShader;
+    Shader* m_BrushShader;
 
-	Shader*						m_CompositeShader;
-	Shader*		                m_FontShader;
-	Shader*						m_ShapesShader;
-	// Offsets into collider batch
-	GLBatchDrawCmd				m_EllipsoidColliderDrawCmd;
+    Shader* m_ImPrimitivesShader;
 
-	CglFBO*		                m_2dFBO;
-	CglFBO*						m_3dFBO;
-	CglFBO*						m_ConsoleFBO;
-	int							m_WindowWidth;
-	int							m_WindowHeight;
+    Shader*  m_ColliderShader;
+    GLBatch* m_ColliderBatch;
 
-	// 2D Rendering state
-	CFont*						m_CurrentFont;
+    Shader* m_CompositeShader;
+    Shader* m_FontShader;
+    Shader* m_ShapesShader;
+    // Offsets into collider batch
+    GLBatchDrawCmd m_EllipsoidColliderDrawCmd;
 
+    CglFBO* m_2dFBO;
+    CglFBO* m_3dFBO;
+    CglFBO* m_ConsoleFBO;
+    int     m_WindowWidth;
+    int     m_WindowHeight;
 
+    // 2D Rendering state
+    CFont* m_CurrentFont;
 };
 
 #endif

--- a/r_gl_batch.cpp
+++ b/r_gl_batch.cpp
@@ -5,11 +5,11 @@
 #include <string>
 
 #define GLM_FORCE_RADIANS
-#include "dependencies/glm/glm.hpp"
 #include "dependencies/glm/ext.hpp"
+#include "dependencies/glm/glm.hpp"
 
 #include "r_common.h"
-#include "r_gl_texture.h" 
+#include "r_gl_texture.h"
 
 //struct Vertex {
 //    glm::vec3 pos;
@@ -21,15 +21,14 @@
 //    glm::vec4 blendweights;
 //};
 
-GLBatch::GLBatch(uint32_t maxVerts)
-{
+GLBatch::GLBatch(uint32_t maxVerts) {
     m_GeometryType = GEOM_TYPE_VERTEX_ONLY;
 
     m_MaxVerts = maxVerts;
 
     m_MaxIndices = 0;
 
-    m_NumVerts = 0;
+    m_NumVerts        = 0;
     m_VertOffsetIndex = 0;
 
     m_IndexOffsetIndex = 0;
@@ -52,7 +51,7 @@ GLBatch::GLBatch(uint32_t maxVerts)
 
     glEnableVertexAttribArray(2); // uv lightmap
     glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)VERT_UV_LIGHTMAP_OFFSET);
-    
+
     glEnableVertexAttribArray(3); // bc
     glVertexAttribPointer(3, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)VERT_BC_OFFSET);
 
@@ -73,19 +72,18 @@ GLBatch::GLBatch(uint32_t maxVerts)
     glBindVertexArray(0);
 }
 
-GLBatch::GLBatch(uint32_t maxVerts, uint32_t maxIndices)
-{
+GLBatch::GLBatch(uint32_t maxVerts, uint32_t maxIndices) {
     m_GeometryType = GEOM_TYPE_INDEXED;
 
-    m_MaxVerts = maxVerts;
+    m_MaxVerts   = maxVerts;
     m_MaxIndices = maxIndices;
 
-    m_NumVerts = 0;
+    m_NumVerts        = 0;
     m_VertOffsetIndex = 0;
 
-    m_NumIndices = 0;
+    m_NumIndices       = 0;
     m_IndexOffsetIndex = 0;
-    m_LastIndex = 0;
+    m_LastIndex        = 0;
 
     glGenVertexArrays(1, &m_VAO);
     glBindVertexArray(m_VAO);
@@ -104,7 +102,7 @@ GLBatch::GLBatch(uint32_t maxVerts, uint32_t maxIndices)
 
     glEnableVertexAttribArray(2); // uv lightmap
     glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)VERT_UV_LIGHTMAP_OFFSET);
-    
+
     glEnableVertexAttribArray(3); // bc
     glVertexAttribPointer(3, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)VERT_BC_OFFSET);
 
@@ -133,9 +131,8 @@ GLBatch::GLBatch(uint32_t maxVerts, uint32_t maxIndices)
 }
 
 // TODO: cullFace and drawMode not used!
-int GLBatch::Add(Tri* tris, uint32_t numTris, bool cullFace, DrawMode drawMode)
-{
-    if (m_VertOffsetIndex + 3*numTris > m_MaxVerts) {
+int GLBatch::Add(Tri* tris, uint32_t numTris, bool cullFace, DrawMode drawMode) {
+    if ( m_VertOffsetIndex + 3 * numTris > m_MaxVerts ) {
         printf("No more space on GPU to upload more triangles!\nSpace available: %d\n", m_MaxVerts - m_VertOffsetIndex);
         return -1;
     }
@@ -144,27 +141,26 @@ int GLBatch::Add(Tri* tris, uint32_t numTris, bool cullFace, DrawMode drawMode)
     glBindBuffer(GL_ARRAY_BUFFER, m_VBO);
     glBufferSubData(GL_ARRAY_BUFFER, m_VertOffsetIndex * sizeof(Vertex), numTris * sizeof(Tri), tris);
     glBindBuffer(GL_ARRAY_BUFFER, 0);
-    glBindVertexArray(0);    
+    glBindVertexArray(0);
 
     int offset = m_VertOffsetIndex;
-    m_VertOffsetIndex += 3*numTris;
+    m_VertOffsetIndex += 3 * numTris;
 
     return offset;
 }
 
 int GLBatch::AddMapTris(MapTri* tris, uint32_t numTris, bool cullFace, DrawMode drawMode) {
     std::vector<Tri> rawTris{};
-    rawTris.resize( numTris );
-    for (int i = 0; i < numTris; i++) {
+    rawTris.resize(numTris);
+    for ( int i = 0; i < numTris; i++ ) {
         rawTris[ i ] = tris[ i ].tri;
     }
-    
-    return Add( rawTris.data(), numTris, cullFace, drawMode );
+
+    return Add(rawTris.data(), numTris, cullFace, drawMode);
 }
 
-int GLBatch::Add(Vertex* verts, uint32_t numVerts, bool cullFace, DrawMode drawMode)
-{
-    if (m_VertOffsetIndex + numVerts > m_MaxVerts) {
+int GLBatch::Add(Vertex* verts, uint32_t numVerts, bool cullFace, DrawMode drawMode) {
+    if ( m_VertOffsetIndex + numVerts > m_MaxVerts ) {
         printf("No more space on GPU to upload more vertices!\nSpace available: %d\n", m_MaxVerts - m_VertOffsetIndex);
         return -1;
     }
@@ -181,15 +177,22 @@ int GLBatch::Add(Vertex* verts, uint32_t numVerts, bool cullFace, DrawMode drawM
     return offset;
 }
 
-bool GLBatch::Add(Vertex* verts, uint32_t numVerts, uint16_t* indices, uint32_t numIndices, int* out_offset, int* out_idxOffset, bool cullFace, DrawMode drawMode)
-{
-    if (m_VertOffsetIndex + numVerts > m_MaxVerts) {
+bool GLBatch::Add(Vertex*   verts,
+                  uint32_t  numVerts,
+                  uint16_t* indices,
+                  uint32_t  numIndices,
+                  int*      out_offset,
+                  int*      out_idxOffset,
+                  bool      cullFace,
+                  DrawMode  drawMode) {
+    if ( m_VertOffsetIndex + numVerts > m_MaxVerts ) {
         printf("No more space on GPU to upload more vertices!\nSpace available: %d\n", m_MaxVerts - m_VertOffsetIndex);
         return false;
     }
 
-    if (m_IndexOffsetIndex + numIndices > m_MaxIndices) {
-        printf("No more space on GPU to upload more indices!\nSpace available: %d\n", m_MaxIndices - m_IndexOffsetIndex);
+    if ( m_IndexOffsetIndex + numIndices > m_MaxIndices ) {
+        printf("No more space on GPU to upload more indices!\nSpace available: %d\n",
+               m_MaxIndices - m_IndexOffsetIndex);
         return false;
     }
 
@@ -202,7 +205,8 @@ bool GLBatch::Add(Vertex* verts, uint32_t numVerts, uint16_t* indices, uint32_t 
     m_VertOffsetIndex += numVerts;
 
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_iVBO);
-    glBufferSubData(GL_ELEMENT_ARRAY_BUFFER, m_IndexOffsetIndex * sizeof(uint16_t), numIndices * sizeof(uint16_t), indices);
+    glBufferSubData(
+        GL_ELEMENT_ARRAY_BUFFER, m_IndexOffsetIndex * sizeof(uint16_t), numIndices * sizeof(uint16_t), indices);
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 
     *out_idxOffset = m_IndexOffsetIndex;
@@ -213,26 +217,25 @@ bool GLBatch::Add(Vertex* verts, uint32_t numVerts, uint16_t* indices, uint32_t 
     return true;
 }
 
-void GLBatch::Bind()
-{
+void GLBatch::Bind() {
     glBindVertexArray(m_VAO);
 
     // WE HAVE TO BIND THIS EXPLICITLY... WHY??? OpenGL is nuts.
-    if (m_GeometryType == GEOM_TYPE_INDEXED) {
+    if ( m_GeometryType == GEOM_TYPE_INDEXED ) {
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_iVBO);
     }
 }
 
 void GLBatch::Unbind() {
-    glBindVertexArray( 0 );
+    glBindVertexArray(0);
 }
 
 void GLBatch::Reset() {
-    m_NumVerts = 0;
-    m_VertOffsetIndex = 0;    
-    m_NumIndices = 0;
+    m_NumVerts         = 0;
+    m_VertOffsetIndex  = 0;
+    m_NumIndices       = 0;
     m_IndexOffsetIndex = 0;
-    m_LastIndex = 0;
+    m_LastIndex        = 0;
 }
 
 void GLBatch::Kill() {
@@ -240,13 +243,10 @@ void GLBatch::Kill() {
     glDeleteVertexArrays(1, &m_VAO);
 }
 
-uint32_t GLBatch::VertCount()
-{
+uint32_t GLBatch::VertCount() {
     return m_VertOffsetIndex;
 }
 
 uint32_t GLBatch::IndexCount() {
     return m_IndexOffsetIndex;
 }
-
-

--- a/r_gl_batch.h
+++ b/r_gl_batch.h
@@ -9,46 +9,53 @@
 
 #include <string>
 
+#include "irender.h"
 #include "r_common.h"
 #include "r_gl_texture.h"
-#include "irender.h"
-
 
 class GLBatch {
-public:
-	GLBatch(uint32_t maxVerts);
-	GLBatch(uint32_t maxVerts, uint32_t maxIndices);
+  public:
+    GLBatch(uint32_t maxVerts);
+    GLBatch(uint32_t maxVerts, uint32_t maxIndices);
 
-	int				Add(Tri* tris, uint32_t numTris, bool cullFace = true, DrawMode drawMode = DRAW_MODE_SOLID);
-	int				AddMapTris(MapTri* tris, uint32_t numTris, bool cullFace = true, DrawMode drawMode = DRAW_MODE_SOLID);
-	int				Add(Vertex* verts, uint32_t numVerts, bool cullFace = true, DrawMode drawMode = DRAW_MODE_LINES);
-	bool			Add(Vertex* verts, uint32_t numVerts, uint16_t* indices, uint32_t numIndices, int* out_offset, int* out_idxOffset, bool cullFace = true, DrawMode drawMode = DRAW_MODE_SOLID);
-	void			Bind();
-	void			Unbind();
-	void			Reset();
-	void			Kill();
+    int  Add(Tri* tris, uint32_t numTris, bool cullFace = true, DrawMode drawMode = DRAW_MODE_SOLID);
+    int  AddMapTris(MapTri* tris, uint32_t numTris, bool cullFace = true, DrawMode drawMode = DRAW_MODE_SOLID);
+    int  Add(Vertex* verts, uint32_t numVerts, bool cullFace = true, DrawMode drawMode = DRAW_MODE_LINES);
+    bool Add(Vertex*   verts,
+             uint32_t  numVerts,
+             uint16_t* indices,
+             uint32_t  numIndices,
+             int*      out_offset,
+             int*      out_idxOffset,
+             bool      cullFace = true,
+             DrawMode  drawMode = DRAW_MODE_SOLID);
+    void Bind();
+    void Unbind();
+    void Reset();
+    void Kill();
 
-	uint32_t		VertCount();
-	uint32_t        IndexCount();
+    uint32_t VertCount();
+    uint32_t IndexCount();
 
-	// FIX: This helps to remember the last index into the vertex buffer. Useful for multiple calls to Add().
-	//		But maybe there is a better way to do this since all calls to Add have to set this value, which
-	//		is easy to forget. It might be an option to track all eg. indexed 2d rendering state
-	//		in the render backend. For now, this is ok.
-	uint16_t    m_LastIndex; 
-private:
-	GeometryType m_GeometryType;
+    // FIX: This helps to remember the last index into the vertex buffer. Useful for multiple calls to Add().
+    //		But maybe there is a better way to do this since all calls to Add have to set this value, which
+    //		is easy to forget. It might be an option to track all eg. indexed 2d rendering state
+    //		in the render backend. For now, this is ok.
+    uint16_t m_LastIndex;
 
-	GLuint		m_VBO, m_VAO;
-	GLuint      m_iVBO;
+  private:
+    GeometryType m_GeometryType;
 
-	uint32_t	m_MaxVerts;
-	uint32_t	m_NumVerts;
-	int			m_VertOffsetIndex;	
+    GLuint m_VBO, m_VAO;
+    GLuint m_iVBO;
 
-	uint32_t	m_MaxIndices;
-	uint32_t	m_NumIndices;
-	int			m_IndexOffsetIndex;
+    uint32_t m_MaxVerts;
+    uint32_t m_NumVerts;
+    int      m_VertOffsetIndex;
+
+    uint32_t m_MaxIndices;
+    uint32_t m_NumIndices;
+    int      m_IndexOffsetIndex;
 };
 
 #endif

--- a/r_gl_fbo.cpp
+++ b/r_gl_fbo.cpp
@@ -8,16 +8,16 @@
 
 // Not usable in this state! Call any of the non-default Ctors to
 // get the FBO into valid state.
-CglFBO::CglFBO() { 
-    m_Width = 0;
+CglFBO::CglFBO() {
+    m_Width  = 0;
     m_Height = 0;
-    m_hFBO = 9999; // TODO: (Michael): Can the handle be 0? Check GL docs!
+    m_hFBO   = 9999; // TODO: (Michael): Can the handle be 0? Check GL docs!
 }
 
 CglFBO::CglFBO(int width, int height) {
-    m_Width = width;
+    m_Width  = width;
     m_Height = height;
-    
+
     glGenFramebuffers(1, &m_hFBO);
 
     Bind();
@@ -27,22 +27,21 @@ CglFBO::CglFBO(int width, int height) {
 
     m_ColorTexture.Bind();
     m_DepthTexture.Bind();
-    
+
     glFramebufferTexture(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, m_ColorTexture.m_gl_Handle, 0);
     glFramebufferTexture(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, m_DepthTexture.m_gl_Handle, 0);
-
 
     static const GLenum drawBuffers[] = { GL_COLOR_ATTACHMENT0 };
     glDrawBuffers(1, drawBuffers);
 
     // Check if framebuffer is complete
     GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
-    if (status != GL_FRAMEBUFFER_COMPLETE) {
+    if ( status != GL_FRAMEBUFFER_COMPLETE ) {
         printf("Framebuffer not complete: 0x%x\n", status);
     } else {
         printf("Framebuffer is complete\n");
     }
-   
+
     Unbind();
 }
 
@@ -58,4 +57,3 @@ void CglFBO::Bind() {
 void CglFBO::Unbind() {
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
 }
-

--- a/r_gl_fbo.h
+++ b/r_gl_fbo.h
@@ -8,20 +8,19 @@
 
 class CglFBO {
 
-public:
+  public:
     CglFBO();
     CglFBO(int width, int height);
     ~CglFBO();
 
-    void Bind(); 
+    void Bind();
     void Unbind();
 
-    int	    m_Width;
-    int	    m_Height;
-    GLuint  m_hFBO;
+    int              m_Width;
+    int              m_Height;
+    GLuint           m_hFBO;
     CglRenderTexture m_ColorTexture;
     CglRenderTexture m_DepthTexture;
 };
 
 #endif
-

--- a/r_gl_rendertexture.cpp
+++ b/r_gl_rendertexture.cpp
@@ -4,41 +4,36 @@
 
 #include <glad/glad.h>
 
-
-CglRenderTexture::CglRenderTexture() 
-{
-    m_Width = 0;
-    m_Height = 0;
+CglRenderTexture::CglRenderTexture() {
+    m_Width     = 0;
+    m_Height    = 0;
     m_gl_Handle = 0;
 }
 
-CglRenderTexture::CglRenderTexture(int width, int height, GLenum format)
-{
-    m_Width = width;
+CglRenderTexture::CglRenderTexture(int width, int height, GLenum format) {
+    m_Width  = width;
     m_Height = height;
 
     glGenTextures(1, &m_gl_Handle);
     glBindTexture(GL_TEXTURE_2D, m_gl_Handle);
-    
-    if (format == GL_RGBA8) {
-	glTexStorage2D(GL_TEXTURE_2D, 1, GL_RGBA8, width, height);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+
+    if ( format == GL_RGBA8 ) {
+        glTexStorage2D(GL_TEXTURE_2D, 1, GL_RGBA8, width, height);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    } 
-    else if (format == GL_DEPTH_COMPONENT32F) {
-	glTexStorage2D(GL_TEXTURE_2D, 1, format, width, height);
-    }
-    else {
-	assert(false && "CglRenderTexture: Unsupported format.");
+    } else if ( format == GL_DEPTH_COMPONENT32F ) {
+        glTexStorage2D(GL_TEXTURE_2D, 1, format, width, height);
+    } else {
+        assert(false && "CglRenderTexture: Unsupported format.");
     }
 
     glBindTexture(GL_TEXTURE_2D, 0);
 }
 
 CglRenderTexture::~CglRenderTexture() {
-    // TODO: (Michael): Nuke from GPU texture memory. 
+    // TODO: (Michael): Nuke from GPU texture memory.
 }
 
 void CglRenderTexture::Bind() {
@@ -48,4 +43,3 @@ void CglRenderTexture::Bind() {
 void CglRenderTexture::Unbind() {
     glBindTexture(GL_TEXTURE_2D, 0);
 }
-

--- a/r_gl_rendertexture.h
+++ b/r_gl_rendertexture.h
@@ -5,14 +5,14 @@
 
 class CglRenderTexture {
 
-public:
+  public:
     CglRenderTexture();
     CglRenderTexture(int width, int height, GLenum format);
     ~CglRenderTexture();
     void Bind();
     void Unbind();
 
-    GLuint         m_gl_Handle;
+    GLuint m_gl_Handle;
     //unsigned char* m_Pixeldata;
     int m_Width;
     int m_Height;

--- a/r_gl_shader.cpp
+++ b/r_gl_shader.cpp
@@ -5,8 +5,8 @@
 #include <stdio.h>
 
 #define GLM_FORCE_RADIANS
-#include "dependencies/glm/glm.hpp"
 #include "dependencies/glm/ext.hpp"
+#include "dependencies/glm/glm.hpp"
 
 #include "platform.h"
 #include "r_common.h"
@@ -21,10 +21,10 @@ extern std::string g_GameDir;
 // TODO: Those BIND_POINT definitions should probably in a non-open-gl
 // header file in the future when creating a new backend with a different API.
 
-#define BIND_POINT_VIEW_PROJECTION    0
-#define BIND_POINT_SETTINGS			  1
-#define BIND_POINT_FONT			3
-#define BIND_POINT_SHAPES		4
+#define BIND_POINT_VIEW_PROJECTION 0
+#define BIND_POINT_SETTINGS 1
+#define BIND_POINT_FONT 3
+#define BIND_POINT_SHAPES 4
 
 static GLuint g_PaletteBindingPoint = 2; // FIX: Not sure about this one.
 
@@ -35,252 +35,244 @@ static GLuint   g_ViewProjUBO;
 static GLuint   g_SettingsUBO;
 static uint32_t g_SettingsBits;
 
-bool Shader::Load(const std::string& vertName, const std::string& fragName, uint32_t shaderFeatureBits)
-{
-	if (!CompileShader(vertName, GL_VERTEX_SHADER, m_VertexShader)
-		|| !CompileShader(fragName, GL_FRAGMENT_SHADER, m_FragmentShader)) {
+bool Shader::Load(const std::string& vertName, const std::string& fragName, uint32_t shaderFeatureBits) {
+    if ( !CompileShader(vertName, GL_VERTEX_SHADER, m_VertexShader)
+         || !CompileShader(fragName, GL_FRAGMENT_SHADER, m_FragmentShader) ) {
 
-		return false;
-	}
+        return false;
+    }
 
-	m_ShaderProgram = glCreateProgram();
-	glAttachShader(m_ShaderProgram, m_VertexShader);
-	glAttachShader(m_ShaderProgram, m_FragmentShader);
-	glLinkProgram(m_ShaderProgram);
+    m_ShaderProgram = glCreateProgram();
+    glAttachShader(m_ShaderProgram, m_VertexShader);
+    glAttachShader(m_ShaderProgram, m_FragmentShader);
+    glLinkProgram(m_ShaderProgram);
 
-	if (!IsValidProgram()) return false;
+    if ( !IsValidProgram() ) return false;
 
-	// Uniforms
+    // Uniforms
 
-	// Per frame matrices
-	//glBindBuffer(GL_UNIFORM_BUFFER, g_ViewProjUBO);
-	GLuint bindingPoint = BIND_POINT_VIEW_PROJECTION;
-	m_ViewProjUniformIndex = glGetUniformBlockIndex(m_ShaderProgram, "ViewProjMatrices");
-	if (m_ViewProjUniformIndex == GL_INVALID_INDEX) {
-		printf("SHADER-WARNING: Not able to get index for UBO in shader program.\nShaders:\n %s\n %s\n", vertName.c_str(), fragName.c_str());
-		// TODO: What to do in this case???
-	}
-	glUniformBlockBinding(m_ShaderProgram, m_ViewProjUniformIndex, bindingPoint);
-	glBindBufferRange(GL_UNIFORM_BUFFER, bindingPoint, g_ViewProjUBO, 0, 2*sizeof(glm::mat4));
-	glBindBuffer(GL_UNIFORM_BUFFER, 0);
+    // Per frame matrices
+    //glBindBuffer(GL_UNIFORM_BUFFER, g_ViewProjUBO);
+    GLuint bindingPoint    = BIND_POINT_VIEW_PROJECTION;
+    m_ViewProjUniformIndex = glGetUniformBlockIndex(m_ShaderProgram, "ViewProjMatrices");
+    if ( m_ViewProjUniformIndex == GL_INVALID_INDEX ) {
+        printf("SHADER-WARNING: Not able to get index for UBO in shader program.\nShaders:\n %s\n %s\n",
+               vertName.c_str(),
+               fragName.c_str());
+        // TODO: What to do in this case???
+    }
+    glUniformBlockBinding(m_ShaderProgram, m_ViewProjUniformIndex, bindingPoint);
+    glBindBufferRange(GL_UNIFORM_BUFFER, bindingPoint, g_ViewProjUBO, 0, 2 * sizeof(glm::mat4));
+    glBindBuffer(GL_UNIFORM_BUFFER, 0);
 
-	// Per frame settings
-	//glBindBuffer(GL_UNIFORM_BUFFER, g_SettingsUBO);
-	GLuint settingsBindingPoint = BIND_POINT_SETTINGS;
-	m_SettingsUniformIndex = glGetUniformBlockIndex(m_ShaderProgram, "Settings");
-	if (m_SettingsUniformIndex == GL_INVALID_INDEX) {
-		printf("SHADER-WARNING: Not able to get index for UBO in shader program.\nShaders:\n %s\n %s\n", vertName.c_str(), fragName.c_str());		
-		// TODO: What to do in this case???
-	}
-	glUniformBlockBinding(m_ShaderProgram, m_SettingsUniformIndex, settingsBindingPoint);
-	glBindBufferRange(GL_UNIFORM_BUFFER, settingsBindingPoint, g_SettingsUBO, 0, 4 * sizeof(uint32_t));
-	glBindBuffer(GL_UNIFORM_BUFFER, 0);
+    // Per frame settings
+    //glBindBuffer(GL_UNIFORM_BUFFER, g_SettingsUBO);
+    GLuint settingsBindingPoint = BIND_POINT_SETTINGS;
+    m_SettingsUniformIndex      = glGetUniformBlockIndex(m_ShaderProgram, "Settings");
+    if ( m_SettingsUniformIndex == GL_INVALID_INDEX ) {
+        printf("SHADER-WARNING: Not able to get index for UBO in shader program.\nShaders:\n %s\n %s\n",
+               vertName.c_str(),
+               fragName.c_str());
+        // TODO: What to do in this case???
+    }
+    glUniformBlockBinding(m_ShaderProgram, m_SettingsUniformIndex, settingsBindingPoint);
+    glBindBufferRange(GL_UNIFORM_BUFFER, settingsBindingPoint, g_SettingsUBO, 0, 4 * sizeof(uint32_t));
+    glBindBuffer(GL_UNIFORM_BUFFER, 0);
 
-	// TODO: Animation stuff is not global to all shaders. That is why we check for shader flags here.
+    // TODO: Animation stuff is not global to all shaders. That is why we check for shader flags here.
 
-	if (shaderFeatureBits & SHADER_FEATURE_MODEL_ANIMATION_BIT) {
+    if ( shaderFeatureBits & SHADER_FEATURE_MODEL_ANIMATION_BIT ) {
 
-		// Per frame per model animation matrix palette
-		GLuint paletteBindingPoint = g_PaletteBindingPoint++; // If a UBO is not being shared between shaders we need separate binding points to these buffers
-		m_PaletteUniformIndex = glGetUniformBlockIndex(m_ShaderProgram, "Palette");
-		if (m_PaletteUniformIndex == GL_INVALID_INDEX) {
-			printf("SHADER-WARNING: Not able to get index for UBO in shader program.\nShaders:\n %s\n %s\n", vertName.c_str(), fragName.c_str());
-			// TODO: What to do in this case???
-		}
-		glUniformBlockBinding(m_ShaderProgram, m_PaletteUniformIndex, paletteBindingPoint);
+        // Per frame per model animation matrix palette
+        GLuint paletteBindingPoint
+            = g_PaletteBindingPoint++; // If a UBO is not being shared between shaders we need separate binding points to these buffers
+        m_PaletteUniformIndex = glGetUniformBlockIndex(m_ShaderProgram, "Palette");
+        if ( m_PaletteUniformIndex == GL_INVALID_INDEX ) {
+            printf("SHADER-WARNING: Not able to get index for UBO in shader program.\nShaders:\n %s\n %s\n",
+                   vertName.c_str(),
+                   fragName.c_str());
+            // TODO: What to do in this case???
+        }
+        glUniformBlockBinding(m_ShaderProgram, m_PaletteUniformIndex, paletteBindingPoint);
 
-		glGenBuffers(1, &m_PaletteUBO);
-		glBindBuffer(GL_UNIFORM_BUFFER, m_PaletteUBO);
-		glBufferData(GL_UNIFORM_BUFFER, MAX_BONES * sizeof(glm::mat4), nullptr, GL_DYNAMIC_DRAW);
-		glBindBufferRange(GL_UNIFORM_BUFFER, paletteBindingPoint, m_PaletteUBO, 0, MAX_BONES*sizeof(glm::mat4));
-		glBindBuffer(GL_UNIFORM_BUFFER, 0);
-	}
+        glGenBuffers(1, &m_PaletteUBO);
+        glBindBuffer(GL_UNIFORM_BUFFER, m_PaletteUBO);
+        glBufferData(GL_UNIFORM_BUFFER, MAX_BONES * sizeof(glm::mat4), nullptr, GL_DYNAMIC_DRAW);
+        glBindBufferRange(GL_UNIFORM_BUFFER, paletteBindingPoint, m_PaletteUBO, 0, MAX_BONES * sizeof(glm::mat4));
+        glBindBuffer(GL_UNIFORM_BUFFER, 0);
+    }
 
-	return true;
+    return true;
 }
 
 void Shader::InitializeFontUniforms() {
-	// TODO: (Michael): Uniform Binding happens quite often (see init shader above). Simplify this.
-    
-	GLuint bindingPoint = BIND_POINT_FONT; 
-	m_FontUniformIndex = glGetUniformBlockIndex(m_ShaderProgram, "fontUB");
-	if (m_FontUniformIndex == GL_INVALID_INDEX) {
-		//printf("SHADER-WARNING: Not able to get index for UBO in shader program.\nShaders:\n %s\n %s\n", vertName.c_str(), fragName.c_str());
+    // TODO: (Michael): Uniform Binding happens quite often (see init shader above). Simplify this.
+
+    GLuint bindingPoint = BIND_POINT_FONT;
+    m_FontUniformIndex  = glGetUniformBlockIndex(m_ShaderProgram, "fontUB");
+    if ( m_FontUniformIndex == GL_INVALID_INDEX ) {
+        //printf("SHADER-WARNING: Not able to get index for UBO in shader program.\nShaders:\n %s\n %s\n", vertName.c_str(), fragName.c_str());
         printf("Not able to bind fontUBO!\n");
-		// TODO: What to do in this case???
-	}
-	glUniformBlockBinding(m_ShaderProgram, m_FontUniformIndex, bindingPoint);
+        // TODO: What to do in this case???
+    }
+    glUniformBlockBinding(m_ShaderProgram, m_FontUniformIndex, bindingPoint);
 
     glGenBuffers(1, &m_FontUBO);
     glBindBuffer(GL_UNIFORM_BUFFER, m_FontUBO);
-    glBufferData( GL_UNIFORM_BUFFER, sizeof(FontUB), nullptr, GL_DYNAMIC_DRAW );
-    glBindBufferRange( GL_UNIFORM_BUFFER, bindingPoint, m_FontUBO, 0, sizeof(FontUB) );
+    glBufferData(GL_UNIFORM_BUFFER, sizeof(FontUB), nullptr, GL_DYNAMIC_DRAW);
+    glBindBufferRange(GL_UNIFORM_BUFFER, bindingPoint, m_FontUBO, 0, sizeof(FontUB));
     glBindBuffer(GL_UNIFORM_BUFFER, 0);
 }
 
 void Shader::InitializeShapesUniforms() {
-	// TODO: (Michael): Uniform Binding happens quite often (see init shader above). Simplify this.
-    
-	GLuint bindingPoint = BIND_POINT_SHAPES; 
-	m_ShapesUniformIndex = glGetUniformBlockIndex(m_ShaderProgram, "shapesUB");
-	if (m_ShapesUniformIndex == GL_INVALID_INDEX) {
-		//printf("SHADER-WARNING: Not able to get index for UBO in shader program.\nShaders:\n %s\n %s\n", vertName.c_str(), fragName.c_str());
+    // TODO: (Michael): Uniform Binding happens quite often (see init shader above). Simplify this.
+
+    GLuint bindingPoint  = BIND_POINT_SHAPES;
+    m_ShapesUniformIndex = glGetUniformBlockIndex(m_ShaderProgram, "shapesUB");
+    if ( m_ShapesUniformIndex == GL_INVALID_INDEX ) {
+        //printf("SHADER-WARNING: Not able to get index for UBO in shader program.\nShaders:\n %s\n %s\n", vertName.c_str(), fragName.c_str());
         printf("Not able to bind shapesUB! n");
-		// TODO: What to do in this case???
-	}
-	glUniformBlockBinding(m_ShaderProgram, m_ShapesUniformIndex, bindingPoint);
+        // TODO: What to do in this case???
+    }
+    glUniformBlockBinding(m_ShaderProgram, m_ShapesUniformIndex, bindingPoint);
 
     glGenBuffers(1, &m_ShapesUBO);
     glBindBuffer(GL_UNIFORM_BUFFER, m_ShapesUBO);
-    glBufferData( GL_UNIFORM_BUFFER, sizeof(ShapesUB), nullptr, GL_DYNAMIC_DRAW );
-    glBindBufferRange( GL_UNIFORM_BUFFER, bindingPoint, m_ShapesUBO, 0, sizeof(ShapesUB) );
+    glBufferData(GL_UNIFORM_BUFFER, sizeof(ShapesUB), nullptr, GL_DYNAMIC_DRAW);
+    glBindBufferRange(GL_UNIFORM_BUFFER, bindingPoint, m_ShapesUBO, 0, sizeof(ShapesUB));
     glBindBuffer(GL_UNIFORM_BUFFER, 0);
 }
-void Shader::Unload()
-{
-	glDeleteProgram(m_ShaderProgram);
-	glDeleteShader(m_VertexShader);
-	glDeleteShader(m_FragmentShader);
+void Shader::Unload() {
+    glDeleteProgram(m_ShaderProgram);
+    glDeleteShader(m_VertexShader);
+    glDeleteShader(m_FragmentShader);
 }
 
-void Shader::Activate()
-{
-	glUseProgram(m_ShaderProgram);
+void Shader::Activate() {
+    glUseProgram(m_ShaderProgram);
 }
 
-GLuint Shader::Program() const
-{
-	return m_ShaderProgram;
+GLuint Shader::Program() const {
+    return m_ShaderProgram;
 }
 
-void Shader::SetViewProjMatrices(glm::mat4 view, glm::mat4 proj)
-{	
-	glBindBuffer(GL_UNIFORM_BUFFER, g_ViewProjUBO);
-	glBufferSubData(GL_UNIFORM_BUFFER, 0, sizeof(glm::mat4), glm::value_ptr(view));
-	glBufferSubData(GL_UNIFORM_BUFFER, sizeof(glm::mat4), sizeof(glm::mat4), glm::value_ptr(proj));
-	glBindBuffer(GL_UNIFORM_BUFFER, 0);
+void Shader::SetViewProjMatrices(glm::mat4 view, glm::mat4 proj) {
+    glBindBuffer(GL_UNIFORM_BUFFER, g_ViewProjUBO);
+    glBufferSubData(GL_UNIFORM_BUFFER, 0, sizeof(glm::mat4), glm::value_ptr(view));
+    glBufferSubData(GL_UNIFORM_BUFFER, sizeof(glm::mat4), sizeof(glm::mat4), glm::value_ptr(proj));
+    glBindBuffer(GL_UNIFORM_BUFFER, 0);
 }
 
-void Shader::SetMatrixPalette(glm::mat4* palette, uint32_t numMatrices)
-{
-	glBindBuffer(GL_UNIFORM_BUFFER, m_PaletteUBO);
-	glBufferSubData(GL_UNIFORM_BUFFER, 0, numMatrices*sizeof(glm::mat4), palette);
-	glBindBuffer(GL_UNIFORM_BUFFER, 0);
+void Shader::SetMatrixPalette(glm::mat4* palette, uint32_t numMatrices) {
+    glBindBuffer(GL_UNIFORM_BUFFER, m_PaletteUBO);
+    glBufferSubData(GL_UNIFORM_BUFFER, 0, numMatrices * sizeof(glm::mat4), palette);
+    glBindBuffer(GL_UNIFORM_BUFFER, 0);
 }
 
-void Shader::SetMat4(std::string uniformName, glm::mat4 mat4)
-{
-	GLuint loc = glGetUniformLocation(m_ShaderProgram, uniformName.c_str());
-	glUniformMatrix4fv(loc, 1, GL_FALSE, (float*)&mat4);
+void Shader::SetMat4(std::string uniformName, glm::mat4 mat4) {
+    GLuint loc = glGetUniformLocation(m_ShaderProgram, uniformName.c_str());
+    glUniformMatrix4fv(loc, 1, GL_FALSE, (float*)&mat4);
 }
 
-void Shader::SetVec3(std::string uniformName, glm::vec3 vec3)
-{
-	GLuint loc = glGetUniformLocation(m_ShaderProgram, uniformName.c_str());
-	glUniform3fv(loc, 1, (float*)&vec3);
+void Shader::SetVec3(std::string uniformName, glm::vec3 vec3) {
+    GLuint loc = glGetUniformLocation(m_ShaderProgram, uniformName.c_str());
+    glUniform3fv(loc, 1, (float*)&vec3);
 }
 
 void Shader::SetVec4(std::string uniformName, glm::vec4 vec4) {
-	GLuint loc = glGetUniformLocation(m_ShaderProgram, uniformName.c_str());
-	glUniform4fv(loc, 1, (float*)&vec4);
+    GLuint loc = glGetUniformLocation(m_ShaderProgram, uniformName.c_str());
+    glUniform4fv(loc, 1, (float*)&vec4);
 }
 
-void Shader::DrawWireframe(uint32_t yesOrNo)
-{		
-	if (yesOrNo) {
-		g_SettingsBits |= SHADER_WIREFRAME_ON_MESH;
-	}
-	glBindBuffer(GL_UNIFORM_BUFFER, g_SettingsUBO);
-	glBufferSubData(GL_UNIFORM_BUFFER, 0, sizeof(uint32_t), (void*)&yesOrNo);
-	glBindBuffer(GL_UNIFORM_BUFFER, 0);
+void Shader::DrawWireframe(uint32_t yesOrNo) {
+    if ( yesOrNo ) {
+        g_SettingsBits |= SHADER_WIREFRAME_ON_MESH;
+    }
+    glBindBuffer(GL_UNIFORM_BUFFER, g_SettingsUBO);
+    glBufferSubData(GL_UNIFORM_BUFFER, 0, sizeof(uint32_t), (void*)&yesOrNo);
+    glBindBuffer(GL_UNIFORM_BUFFER, 0);
 }
 
-void Shader::SetShaderSettingBits(uint32_t bits)
-{
-	g_SettingsBits |= bits;
-	ShaderSettings settings;
-	settings.u32bitMasks.x = g_SettingsBits;
-	glBindBuffer(GL_UNIFORM_BUFFER, g_SettingsUBO);
-	glBufferSubData(GL_UNIFORM_BUFFER, 0, 4 * sizeof(uint32_t), (void*)&settings);
-	glBindBuffer(GL_UNIFORM_BUFFER, 0);
+void Shader::SetShaderSettingBits(uint32_t bits) {
+    g_SettingsBits |= bits;
+    ShaderSettings settings;
+    settings.u32bitMasks.x = g_SettingsBits;
+    glBindBuffer(GL_UNIFORM_BUFFER, g_SettingsUBO);
+    glBufferSubData(GL_UNIFORM_BUFFER, 0, 4 * sizeof(uint32_t), (void*)&settings);
+    glBindBuffer(GL_UNIFORM_BUFFER, 0);
 }
 
-void Shader::ResetShaderSettingBits(uint32_t bits)
-{
-	g_SettingsBits = (g_SettingsBits & (~bits));
-	glBindBuffer(GL_UNIFORM_BUFFER, g_SettingsUBO);
-	glBufferSubData(GL_UNIFORM_BUFFER, 0, 4*sizeof(uint32_t), (void*)&g_SettingsBits);
-	glBindBuffer(GL_UNIFORM_BUFFER, 0);
+void Shader::ResetShaderSettingBits(uint32_t bits) {
+    g_SettingsBits = (g_SettingsBits & (~bits));
+    glBindBuffer(GL_UNIFORM_BUFFER, g_SettingsUBO);
+    glBufferSubData(GL_UNIFORM_BUFFER, 0, 4 * sizeof(uint32_t), (void*)&g_SettingsBits);
+    glBindBuffer(GL_UNIFORM_BUFFER, 0);
 }
 
-void Shader::InitGlobalBuffers()
-{
-	printf("INITIALIZE GLOBAL SHADER BUFFERS...\n");
+void Shader::InitGlobalBuffers() {
+    printf("INITIALIZE GLOBAL SHADER BUFFERS...\n");
 
-	// view projection matrices
-	
-	glGenBuffers(1, &g_ViewProjUBO);
-	glBindBuffer(GL_UNIFORM_BUFFER, g_ViewProjUBO);
-	glBufferData(GL_UNIFORM_BUFFER, 2 * sizeof(glm::mat4), nullptr, GL_DYNAMIC_DRAW);
-	glBindBuffer(GL_UNIFORM_BUFFER, 0);
+    // view projection matrices
 
-	// render settings (such as wireframe)
+    glGenBuffers(1, &g_ViewProjUBO);
+    glBindBuffer(GL_UNIFORM_BUFFER, g_ViewProjUBO);
+    glBufferData(GL_UNIFORM_BUFFER, 2 * sizeof(glm::mat4), nullptr, GL_DYNAMIC_DRAW);
+    glBindBuffer(GL_UNIFORM_BUFFER, 0);
 
-	glGenBuffers(1, &g_SettingsUBO);
-	glBindBuffer(GL_UNIFORM_BUFFER, g_SettingsUBO);
-	glBufferData(GL_UNIFORM_BUFFER, 4 * sizeof(uint32_t), nullptr, GL_DYNAMIC_DRAW);
-	glBindBuffer(GL_UNIFORM_BUFFER, 0);
+    // render settings (such as wireframe)
+
+    glGenBuffers(1, &g_SettingsUBO);
+    glBindBuffer(GL_UNIFORM_BUFFER, g_SettingsUBO);
+    glBufferData(GL_UNIFORM_BUFFER, 4 * sizeof(uint32_t), nullptr, GL_DYNAMIC_DRAW);
+    glBindBuffer(GL_UNIFORM_BUFFER, 0);
 }
 
-bool Shader::CompileShader(const std::string& fileName, GLenum shaderType, GLuint& outShader)
-{
-	std::string shaderFilePath = g_GameDir + fileName;
-	HKD_File shaderCode;
-	if (hkd_read_file(shaderFilePath.c_str(), &shaderCode) != HKD_FILE_SUCCESS) {
-		printf("Could not read file: %s!\n", fileName.c_str());
-		return false;
-	}
+bool Shader::CompileShader(const std::string& fileName, GLenum shaderType, GLuint& outShader) {
+    std::string shaderFilePath = g_GameDir + fileName;
+    HKD_File    shaderCode;
+    if ( hkd_read_file(shaderFilePath.c_str(), &shaderCode) != HKD_FILE_SUCCESS ) {
+        printf("Could not read file: %s!\n", fileName.c_str());
+        return false;
+    }
 
-	outShader = glCreateShader(shaderType);
-	glShaderSource(outShader, 1, (GLchar**)(&shaderCode.data), nullptr);
-	glCompileShader(outShader);
+    outShader = glCreateShader(shaderType);
+    glShaderSource(outShader, 1, (GLchar**)(&shaderCode.data), nullptr);
+    glCompileShader(outShader);
 
-	if (!IsCompiled(outShader)) {
-		printf("Failed to compile shader: %s\n", fileName.c_str());
-		return false;
-	}
+    if ( !IsCompiled(outShader) ) {
+        printf("Failed to compile shader: %s\n", fileName.c_str());
+        return false;
+    }
 
-	return true;
+    return true;
 }
 
-bool Shader::IsCompiled(GLuint shader)
-{
-	GLint status;
-	glGetShaderiv(shader, GL_COMPILE_STATUS, &status);
-	if (status != GL_TRUE) {
-		char buffer[512];
-		memset(buffer, 0, 512);
-		glGetShaderInfoLog(shader, 511, nullptr, buffer);
-		printf("GLSL compile error:\n%s\n", buffer);
+bool Shader::IsCompiled(GLuint shader) {
+    GLint status;
+    glGetShaderiv(shader, GL_COMPILE_STATUS, &status);
+    if ( status != GL_TRUE ) {
+        char buffer[ 512 ];
+        memset(buffer, 0, 512);
+        glGetShaderInfoLog(shader, 511, nullptr, buffer);
+        printf("GLSL compile error:\n%s\n", buffer);
 
-		return false;
-	}
+        return false;
+    }
 
-	return true;
+    return true;
 }
 
-bool Shader::IsValidProgram()
-{
-	GLint status;
-	glGetProgramiv(m_ShaderProgram, GL_LINK_STATUS, &status);
-	if (status != GL_TRUE) {
-		char buffer[512];
-		memset(buffer, 0, 512);
-		glGetProgramInfoLog(m_ShaderProgram, 512, nullptr, buffer);
-		printf("GLSL compile error:\n%s\n", buffer);
+bool Shader::IsValidProgram() {
+    GLint status;
+    glGetProgramiv(m_ShaderProgram, GL_LINK_STATUS, &status);
+    if ( status != GL_TRUE ) {
+        char buffer[ 512 ];
+        memset(buffer, 0, 512);
+        glGetProgramInfoLog(m_ShaderProgram, 512, nullptr, buffer);
+        printf("GLSL compile error:\n%s\n", buffer);
 
-		return false;
-	}
+        return false;
+    }
 
-	return true;
+    return true;
 }

--- a/r_gl_shader.h
+++ b/r_gl_shader.h
@@ -4,8 +4,8 @@
 #include <glad/glad.h>
 
 #define GLM_FORCE_RADIANS
-#include "dependencies/glm/glm.hpp"
 #include "dependencies/glm/ext.hpp"
+#include "dependencies/glm/glm.hpp"
 
 #include <string>
 
@@ -13,61 +13,58 @@
 
 #define MAX_BONES 96
 
-
 #define SHADER_FEATURE_MODEL_ANIMATION_BIT (0x00000001)
-#define SHADER_FEATURE_MAX				   (0x00000001 << 1)
-
+#define SHADER_FEATURE_MAX (0x00000001 << 1)
 
 // TODO: (Michael): Change classname to CglShader or something like that to make clear this is GL specific.
 class Shader {
-public:
-	
-	bool Load(const std::string& vertName, const std::string& fragName, uint32_t shaderFeatureBits = 0x0);
-	void Unload();
-	void Activate();
-	GLuint Program() const;
+  public:
+    bool   Load(const std::string& vertName, const std::string& fragName, uint32_t shaderFeatureBits = 0x0);
+    void   Unload();
+    void   Activate();
+    GLuint Program() const;
 
-	bool operator==(const Shader& rhs) { return m_ShaderProgram == rhs.m_ShaderProgram; }
+    bool operator==(const Shader& rhs) {
+        return m_ShaderProgram == rhs.m_ShaderProgram;
+    }
 
-	void SetViewProjMatrices(glm::mat4 view, glm::mat4 proj);
-	void SetMatrixPalette(glm::mat4* palette, uint32_t numMatrices);
-	void SetMat4(std::string uniformName, glm::mat4 mat4);
-	void SetVec3(std::string uniformName, glm::vec3 vec3);
-	void SetVec4(std::string uniformName, glm::vec4 vec4);
-	void DrawWireframe(uint32_t yesOrNo);
-	void SetShaderSettingBits(uint32_t bits);
-	void ResetShaderSettingBits(uint32_t bits);
-	void InitializeFontUniforms();
-	void InitializeShapesUniforms();
-	static void InitGlobalBuffers();
+    void        SetViewProjMatrices(glm::mat4 view, glm::mat4 proj);
+    void        SetMatrixPalette(glm::mat4* palette, uint32_t numMatrices);
+    void        SetMat4(std::string uniformName, glm::mat4 mat4);
+    void        SetVec3(std::string uniformName, glm::vec3 vec3);
+    void        SetVec4(std::string uniformName, glm::vec4 vec4);
+    void        DrawWireframe(uint32_t yesOrNo);
+    void        SetShaderSettingBits(uint32_t bits);
+    void        ResetShaderSettingBits(uint32_t bits);
+    void        InitializeFontUniforms();
+    void        InitializeShapesUniforms();
+    static void InitGlobalBuffers();
 
-	// Some people would say this must be private. But I find it
-	// a bit dumb to have a getter for this. Just don't assign
-	// a new value to this UBO handle, ok? Thanks!
-	GLuint m_FontUBO;
-	GLuint m_ShapesUBO;
+    // Some people would say this must be private. But I find it
+    // a bit dumb to have a getter for this. Just don't assign
+    // a new value to this UBO handle, ok? Thanks!
+    GLuint m_FontUBO;
+    GLuint m_ShapesUBO;
 
-private:
-	bool CompileShader(const std::string& fileName, GLenum shaderType, GLuint& outShader);
-	bool IsCompiled(GLuint shader);
-	bool IsValidProgram();
+  private:
+    bool CompileShader(const std::string& fileName, GLenum shaderType, GLuint& outShader);
+    bool IsCompiled(GLuint shader);
+    bool IsValidProgram();
 
-	GLuint m_VertexShader;
-	GLuint m_FragmentShader;
-	GLuint m_ShaderProgram;
+    GLuint m_VertexShader;
+    GLuint m_FragmentShader;
+    GLuint m_ShaderProgram;
 
-	GLuint m_ViewProjUniformIndex;
-	GLuint m_SettingsUniformIndex;
-	GLuint m_PaletteUniformIndex;
-	GLuint m_ViewProjUBO;
-	GLuint m_SettingsUBO;
-	GLuint m_PaletteUBO;
+    GLuint m_ViewProjUniformIndex;
+    GLuint m_SettingsUniformIndex;
+    GLuint m_PaletteUniformIndex;
+    GLuint m_ViewProjUBO;
+    GLuint m_SettingsUBO;
+    GLuint m_PaletteUBO;
 
-	// 2d screenspace uniforms
-	GLuint m_FontUniformIndex;
-	GLuint m_ShapesUniformIndex;
+    // 2d screenspace uniforms
+    GLuint m_FontUniformIndex;
+    GLuint m_ShapesUniformIndex;
 };
 
-
 #endif
-

--- a/r_gl_texture.cpp
+++ b/r_gl_texture.cpp
@@ -1,8 +1,8 @@
 #include "r_gl_texture.h"
 
-#include "r_itexture.h"
 #include "platform.h"
 #include "r_font.h"
+#include "r_itexture.h"
 #include "stb_image.h"
 
 #include <assert.h>
@@ -12,16 +12,15 @@ extern std::string g_GameDir;
 
 // TODO: This is the texture manager at the moment...
 
-GLTexture::GLTexture(std::string filename)
-{
+GLTexture::GLTexture(std::string filename) {
     m_Pixeldata = NULL; // TODO: (Michael): We could keep the original pixel data in
     // the future?
 
-    std::string filePath = g_GameDir + "textures/" + filename;
-    int x, y, n;
+    std::string    filePath = g_GameDir + "textures/" + filename;
+    int            x, y, n;
     unsigned char* data = stbi_load(filePath.c_str(), &x, &y, &n, 4);
 
-    if (!data) {
+    if ( !data ) {
         printf("WARNING: Failed to load texture: %s\n", filename.c_str());
         // return {}; // TODO: Load checkerboard texture instead.
     }
@@ -34,24 +33,24 @@ GLTexture::GLTexture(std::string filename)
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glBindTexture(GL_TEXTURE_2D, 0);
 
-    stbi_image_free(data); m_Filename = filename;
+    stbi_image_free(data);
+    m_Filename  = filename;
     m_gl_Handle = glTextureHandle;
-    m_Width= x;
-    m_Height = y;
-    m_Channels = 4;
+    m_Width     = x;
+    m_Height    = y;
+    m_Channels  = 4;
 
-    m_hGPU = (uint64_t)glTextureHandle;    
+    m_hGPU = (uint64_t)glTextureHandle;
 }
 
-GLTexture::GLTexture(CFont* font)
-{
+GLTexture::GLTexture(CFont* font) {
     m_Pixeldata = NULL; // TODO: (Michael): We could keep the original pixel data in
     // the future?
-    
-    assert( font->m_Bitmap != NULL && "GLTexture: Cannot create GLTexture from font, because the font-bitmap is NULL!" );
 
-    int x = FONT_TEX_SIZE;
-    int y = FONT_TEX_SIZE;
+    assert(font->m_Bitmap != NULL && "GLTexture: Cannot create GLTexture from font, because the font-bitmap is NULL!");
+
+    int    x = FONT_TEX_SIZE;
+    int    y = FONT_TEX_SIZE;
     GLuint glTextureHandle;
     glGenTextures(1, &glTextureHandle);
     glBindTexture(GL_TEXTURE_2D, glTextureHandle);
@@ -59,12 +58,11 @@ GLTexture::GLTexture(CFont* font)
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     glBindTexture(GL_TEXTURE_2D, 0);
 
-    m_Filename = font->m_Filename;
+    m_Filename  = font->m_Filename;
     m_gl_Handle = glTextureHandle;
-    m_Width= x;
-    m_Height = y;
-    m_Channels = 1;
+    m_Width     = x;
+    m_Height    = y;
+    m_Channels  = 1;
 
-    m_hGPU = (uint64_t)glTextureHandle;    
+    m_hGPU = (uint64_t)glTextureHandle;
 }
-

--- a/r_gl_texture.h
+++ b/r_gl_texture.h
@@ -6,12 +6,12 @@
 #include <string>
 #include <unordered_map>
 
-#include "r_itexture.h"
 #include "r_font.h"
+#include "r_itexture.h"
 
 class GLTexture : public ITexture {
-public:
-    GLTexture(std::string filename); 
+  public:
+    GLTexture(std::string filename);
     GLTexture(CFont* font);
 
     // TODO: (Michael) Nuke texture from GPU memory
@@ -19,7 +19,5 @@ public:
     GLuint         m_gl_Handle;
     unsigned char* m_Pixeldata;
 };
-
-
 
 #endif

--- a/r_gl_texture_mgr.cpp
+++ b/r_gl_texture_mgr.cpp
@@ -1,74 +1,68 @@
 #include "r_gl_texture_mgr.h"
 
-#include "r_itexture.h"
 #include "r_font.h"
 #include "r_gl_texture.h"
+#include "r_itexture.h"
 
 #include <assert.h>
 
-GLTextureManager::GLTextureManager() {
+GLTextureManager::GLTextureManager() {}
 
+GLTextureManager* GLTextureManager::Instance() {
+    static GLTextureManager theOneAndOnly;
+    return &theOneAndOnly;
 }
 
-GLTextureManager* GLTextureManager::Instance()
-{
-	static GLTextureManager theOneAndOnly;
-	return &theOneAndOnly;
-}
+ITexture* GLTextureManager::CreateTexture(std::string filename) {
+    if ( m_NameToTexture.contains(filename) ) {
+        return m_NameToTexture.at(filename);
+    }
 
-ITexture* GLTextureManager::CreateTexture(std::string filename)
-{
-	if (m_NameToTexture.contains(filename)) {
-		return m_NameToTexture.at(filename);
-	}
+    ITexture* result = new GLTexture(filename);
 
-	ITexture* result = new GLTexture(filename);
+    m_NameToTexture.insert({ filename, result });
+    m_HandleToTexture.insert({ result->m_hGPU, result });
 
-	m_NameToTexture.insert({ filename, result });
-	m_HandleToTexture.insert({ result->m_hGPU, result });
-
-	return result;
+    return result;
 }
 
 uint64_t GLTextureManager::CreateTextureGetHandle(std::string filename) {
-	ITexture* texture = CreateTexture(filename);
-	assert( texture != NULL && "Return of CreateTexture is NULL!" );
+    ITexture* texture = CreateTexture(filename);
+    assert(texture != NULL && "Return of CreateTexture is NULL!");
 
-	return texture->m_hGPU;
+    return texture->m_hGPU;
 }
 
-ITexture* GLTextureManager::CreateTexture(CFont* font)
-{
-	if (m_NameToTexture.contains(font->m_Filename)) {
-		return m_NameToTexture.at(font->m_Filename);
-	}
+ITexture* GLTextureManager::CreateTexture(CFont* font) {
+    if ( m_NameToTexture.contains(font->m_Filename) ) {
+        return m_NameToTexture.at(font->m_Filename);
+    }
 
-	ITexture* result = new GLTexture(font);
+    ITexture* result = new GLTexture(font);
 
-	m_NameToTexture.insert({ font->m_Filename, result });
-	m_HandleToTexture.insert({ result->m_hGPU, result });
+    m_NameToTexture.insert({ font->m_Filename, result });
+    m_HandleToTexture.insert({ result->m_hGPU, result });
 
-	return result;
+    return result;
 }
 
 ITexture* GLTextureManager::GetTexture(std::string filename) {
 
-	if ( m_NameToTexture.contains(filename) ) {
-		return m_NameToTexture.at(filename);
-	}
+    if ( m_NameToTexture.contains(filename) ) {
+        return m_NameToTexture.at(filename);
+    }
 
-	printf("WARNING: GetTexture(): tried to get texture '%s', but not available!\n", filename.c_str());
+    printf("WARNING: GetTexture(): tried to get texture '%s', but not available!\n", filename.c_str());
 
-	return NULL; // TODO: return checkerboard texture.
+    return NULL; // TODO: return checkerboard texture.
 }
 
 ITexture* GLTextureManager::GetTexture(uint64_t handle) {
-	if ( m_HandleToTexture.contains(handle) ) {
-		return m_HandleToTexture.at(handle);
-	}
-	
-	printf("WARNING: GetTexture(): tried to get texture by handle: '%lu', but not available!\n", handle);
+    if ( m_HandleToTexture.contains(handle) ) {
+        return m_HandleToTexture.at(handle);
+    }
 
-	return NULL; // TODO: return checkerboard texture. 
+    printf("WARNING: GetTexture(): tried to get texture by handle: '%lu', but not available!\n", handle);
+
+    return NULL; // TODO: return checkerboard texture.
 }
-

--- a/r_gl_texture_mgr.h
+++ b/r_gl_texture_mgr.h
@@ -10,23 +10,22 @@
 #include "r_itexture.h"
 
 class GLTextureManager {
-public:
-	static GLTextureManager* Instance();
-	
-	ITexture* CreateTexture(std::string filename);
-	uint64_t  CreateTextureGetHandle(std::string filename);
-	ITexture* CreateTexture(CFont* font);
-	ITexture* GetTexture(std::string filename);
-	ITexture* GetTexture(uint64_t handle);
+  public:
+    static GLTextureManager* Instance();
 
-	// TODO: Shutdown methods
+    ITexture* CreateTexture(std::string filename);
+    uint64_t  CreateTextureGetHandle(std::string filename);
+    ITexture* CreateTexture(CFont* font);
+    ITexture* GetTexture(std::string filename);
+    ITexture* GetTexture(uint64_t handle);
 
-	std::unordered_map<std::string, ITexture*>	m_NameToTexture;
-	std::unordered_map<uint64_t, ITexture*>		m_HandleToTexture;
+    // TODO: Shutdown methods
 
-private:
-	GLTextureManager();
-	
+    std::unordered_map<std::string, ITexture*> m_NameToTexture;
+    std::unordered_map<uint64_t, ITexture*>    m_HandleToTexture;
+
+  private:
+    GLTextureManager();
 };
 
 #endif

--- a/r_itexture.h
+++ b/r_itexture.h
@@ -5,11 +5,10 @@
 #include <string>
 
 class ITexture {
-public:
-	std::string    m_Filename;
-	int            m_Width, m_Height, m_Channels;
-	uint64_t       m_hGPU; // GPU side handle. Assigned by Renderbackend.
+  public:
+    std::string m_Filename;
+    int         m_Width, m_Height, m_Channels;
+    uint64_t    m_hGPU; // GPU side handle. Assigned by Renderbackend.
 };
 
 #endif
-

--- a/r_model.cpp
+++ b/r_model.cpp
@@ -2,16 +2,15 @@
 
 #include <unordered_map>
 
-
 #define GLM_FORCE_RADIANS
-#include "dependencies/glm/glm.hpp"
 #include "dependencies/glm/ext.hpp"
+#include "dependencies/glm/glm.hpp"
 #include "dependencies/glm/gtx/quaternion.hpp"
 
-#include "r_common.h"
 #include "collision.h"
 #include "map_parser.h"
 #include "polysoup.h"
+#include "r_common.h"
 
 //glm::vec3 pos;
 //glm::vec3 uv;
@@ -23,44 +22,43 @@
 
 Vertex IQMVertexToVertex(IQMVertex iqmVert, glm::vec3 bc) {
     Vertex vertex = {
-        .pos = glm::vec3(iqmVert.pos[0], iqmVert.pos[1], iqmVert.pos[2]),
-        .uv = glm::vec2(iqmVert.texCoord[0], iqmVert.texCoord[1]),
-        .bc = bc,
-        .normal = glm::vec3(iqmVert.normal[0], iqmVert.normal[1], iqmVert.normal[2]),
-        .color = glm::vec4(iqmVert.color[0], iqmVert.color[1], iqmVert.color[2], iqmVert.color[3]),
-        .blendweights = glm::vec4(iqmVert.blendweights[0], iqmVert.blendweights[1], iqmVert.blendweights[2], iqmVert.blendweights[3])
+        .pos          = glm::vec3(iqmVert.pos[ 0 ], iqmVert.pos[ 1 ], iqmVert.pos[ 2 ]),
+        .uv           = glm::vec2(iqmVert.texCoord[ 0 ], iqmVert.texCoord[ 1 ]),
+        .bc           = bc,
+        .normal       = glm::vec3(iqmVert.normal[ 0 ], iqmVert.normal[ 1 ], iqmVert.normal[ 2 ]),
+        .color        = glm::vec4(iqmVert.color[ 0 ], iqmVert.color[ 1 ], iqmVert.color[ 2 ], iqmVert.color[ 3 ]),
+        .blendweights = glm::vec4(
+            iqmVert.blendweights[ 0 ], iqmVert.blendweights[ 1 ], iqmVert.blendweights[ 2 ], iqmVert.blendweights[ 3 ])
     };
     vertex.blendweights /= 255.0f;
-    vertex.blendindices[0] = iqmVert.blendindices[0];
-    vertex.blendindices[1] = iqmVert.blendindices[1];
-    vertex.blendindices[2] = iqmVert.blendindices[2];
-    vertex.blendindices[3] = iqmVert.blendindices[3];
+    vertex.blendindices[ 0 ] = iqmVert.blendindices[ 0 ];
+    vertex.blendindices[ 1 ] = iqmVert.blendindices[ 1 ];
+    vertex.blendindices[ 2 ] = iqmVert.blendindices[ 2 ];
+    vertex.blendindices[ 3 ] = iqmVert.blendindices[ 3 ];
 
     return vertex;
 }
 
-HKD_Model CreateModelFromIQM(IQMModel* model)
-{
+HKD_Model CreateModelFromIQM(IQMModel* model) {
     HKD_Model result = {};
 
-    for (int i = 0; i < model->meshes.size(); i++) {
-        IQMMesh* iqmMesh = &model->meshes[i];
-        HKD_Mesh mesh = {};
-        if (iqmMesh->material.empty()) {
+    for ( int i = 0; i < model->meshes.size(); i++ ) {
+        IQMMesh* iqmMesh = &model->meshes[ i ];
+        HKD_Mesh mesh    = {};
+        if ( iqmMesh->material.empty() ) {
             mesh.isTextured = false;
-        }
-        else {
+        } else {
             mesh.isTextured = true;
         }
-        
-        mesh.textureFileName = iqmMesh->material;
-        mesh.firstTri = iqmMesh->firstTri;
-        mesh.numTris = iqmMesh->numTris;
-        for (int v = 0; v < iqmMesh->vertices.size(); v += 3) {
 
-            IQMVertex iqmVertA = iqmMesh->vertices[v + 0];
-            IQMVertex iqmVertB = iqmMesh->vertices[v + 1];
-            IQMVertex iqmVertC = iqmMesh->vertices[v + 2];
+        mesh.textureFileName = iqmMesh->material;
+        mesh.firstTri        = iqmMesh->firstTri;
+        mesh.numTris         = iqmMesh->numTris;
+        for ( int v = 0; v < iqmMesh->vertices.size(); v += 3 ) {
+
+            IQMVertex iqmVertA = iqmMesh->vertices[ v + 0 ];
+            IQMVertex iqmVertB = iqmMesh->vertices[ v + 1 ];
+            IQMVertex iqmVertC = iqmMesh->vertices[ v + 2 ];
 
             Vertex vertA = IQMVertexToVertex(iqmVertA, glm::vec3(1.0, 0.0, 0.0));
             Vertex vertB = IQMVertexToVertex(iqmVertB, glm::vec3(0.0, 1.0, 0.0));
@@ -81,42 +79,42 @@ HKD_Model CreateModelFromIQM(IQMModel* model)
     // Might be changed later. Hopefully good enough for the start.
 
     int i = 0;
-    for (; i < model->animations.size(); i++) {
-        Anim a = model->animations[i];
-        Frame f = model->frameData[a.firstFrame];
+    for ( ; i < model->animations.size(); i++ ) {
+        Anim  a = model->animations[ i ];
+        Frame f = model->frameData[ a.firstFrame ];
         result.aabbs.push_back({ f.bbmins, f.bbmins });
-        Box aabbBox = CreateBoxFromAABB(f.bbmins, f.bbmaxs);        
+        Box aabbBox = CreateBoxFromAABB(f.bbmins, f.bbmaxs);
         result.aabbBoxes.push_back(aabbBox);
         EllipsoidCollider ec = CreateEllipsoidColliderFromAABB(f.bbmins, f.bbmaxs);
         result.ellipsoidColliders.push_back(ec);
     }
 
-    if (i > 0) {
+    if ( i > 0 ) {
         result.type = HKD_MODEL_TYPE_ANIMATED;
-		// TODO: This is just for testing the collision detection.
-		// Later we actually want to use dedicated colliders for each animation!
-		EllipsoidCollider ec = result.ellipsoidColliders[0];
-		for (int i = 0; i < result.ellipsoidColliders.size(); i++) {
-			result.ellipsoidColliders[i] = ec;
-		}
+        // TODO: This is just for testing the collision detection.
+        // Later we actually want to use dedicated colliders for each animation!
+        EllipsoidCollider ec = result.ellipsoidColliders[ 0 ];
+        for ( int i = 0; i < result.ellipsoidColliders.size(); i++ ) {
+            result.ellipsoidColliders[ i ] = ec;
+        }
     } else {
         result.type = HKD_MODEL_TYPE_STATIC;
     }
 
-    result.position     = glm::vec3(0.0f);
-    result.orientation  = glm::angleAxis(glm::radians(0.0f), glm::vec3(0.0f, 0.0f, 1.0f));
-    result.scale        = glm::vec3(1.0f);
-    result.filename     = model->filename;
-    result.poses        = model->poses;
-    result.invBindPoses = model->invBindPoses;
-    result.bindPoses    = model->bindPoses;
-    result.numJoints    = model->numJoints;
-    result.animations   = model->animations;
-    result.numFrames    = model->numFrames;
+    result.position       = glm::vec3(0.0f);
+    result.orientation    = glm::angleAxis(glm::radians(0.0f), glm::vec3(0.0f, 0.0f, 1.0f));
+    result.scale          = glm::vec3(1.0f);
+    result.filename       = model->filename;
+    result.poses          = model->poses;
+    result.invBindPoses   = model->invBindPoses;
+    result.bindPoses      = model->bindPoses;
+    result.numJoints      = model->numJoints;
+    result.animations     = model->animations;
+    result.numFrames      = model->numFrames;
     result.currentAnimIdx = 0;
-    result.pctFrameDone = 0.0f;
+    result.pctFrameDone   = 0.0f;
     result.palette.resize(model->numJoints);
-    result.gpuModelHandle = -1;    
+    result.gpuModelHandle = -1;
 
     return result;
 }
@@ -124,20 +122,14 @@ HKD_Model CreateModelFromIQM(IQMModel* model)
 // Assume only triangles for each MapPoly.
 std::vector<Tri> CreateTrisFromMapPolys(std::vector<MapPolygon>& mapPolys) {
     std::vector<Tri> tris{};
-    for (int i = 0; i < mapPolys.size(); i++) {
-        MapPolygon& mapPoly = mapPolys[i];
-        assert( mapPoly.vertices.size() == 3 );
-        Vertex A = { glm::vec3(mapPoly.vertices[ 0 ].pos.x, 
-                               mapPoly.vertices[ 0 ].pos.y, 
-                               mapPoly.vertices[ 0 ].pos.z),
-                    mapPoly.vertices[ 0 ].uv };
-        Vertex B = { glm::vec3(mapPoly.vertices[ 1 ].pos.x, 
-                               mapPoly.vertices[ 1 ].pos.y, 
-                               mapPoly.vertices[ 1 ].pos.z),
+    for ( int i = 0; i < mapPolys.size(); i++ ) {
+        MapPolygon& mapPoly = mapPolys[ i ];
+        assert(mapPoly.vertices.size() == 3);
+        Vertex A = { glm::vec3(mapPoly.vertices[ 0 ].pos.x, mapPoly.vertices[ 0 ].pos.y, mapPoly.vertices[ 0 ].pos.z),
+                     mapPoly.vertices[ 0 ].uv };
+        Vertex B = { glm::vec3(mapPoly.vertices[ 1 ].pos.x, mapPoly.vertices[ 1 ].pos.y, mapPoly.vertices[ 1 ].pos.z),
                      mapPoly.vertices[ 1 ].uv };
-        Vertex C = { glm::vec3(mapPoly.vertices[ 2 ].pos.x, 
-                               mapPoly.vertices[ 2 ].pos.y, 
-                               mapPoly.vertices[ 2 ].pos.z),
+        Vertex C = { glm::vec3(mapPoly.vertices[ 2 ].pos.x, mapPoly.vertices[ 2 ].pos.y, mapPoly.vertices[ 2 ].pos.z),
                      mapPoly.vertices[ 2 ].uv };
 
         Tri tri = { A, B, C };
@@ -149,20 +141,19 @@ std::vector<Tri> CreateTrisFromMapPolys(std::vector<MapPolygon>& mapPolys) {
 
 HKD_Model CreateModelFromBrushes(const std::vector<Brush>& brushes) {
     // Convert brushes to tris and sort them according to their texture name.
-    std::unordered_map<std::string, std::vector<MapPolygon> > texName2polygons{};
-    size_t totalTris = 0;
-    for (int i = 0; i < brushes.size(); i++) {
-        const Brush& brush = brushes[i];
-        std::vector<MapPolygon> polys = createPolysoup(brush);
+    std::unordered_map<std::string, std::vector<MapPolygon>> texName2polygons{};
+    size_t                                                   totalTris = 0;
+    for ( int i = 0; i < brushes.size(); i++ ) {
+        const Brush&            brush   = brushes[ i ];
+        std::vector<MapPolygon> polys   = createPolysoup(brush);
         std::vector<MapPolygon> mapTris = triangulate(polys);
         totalTris += mapTris.size();
-        for (int j = 0; j < mapTris.size(); j++) {
-            MapPolygon& mapTri = mapTris[j];
-            const auto& entry = texName2polygons.find(mapTri.textureName);
+        for ( int j = 0; j < mapTris.size(); j++ ) {
+            MapPolygon& mapTri = mapTris[ j ];
+            const auto& entry  = texName2polygons.find(mapTri.textureName);
             if ( entry == texName2polygons.end() ) {
-                texName2polygons.insert({ mapTri.textureName, {mapTri} });
-            }
-            else {
+                texName2polygons.insert({ mapTri.textureName, { mapTri } });
+            } else {
                 entry->second.push_back(mapTri);
             }
         }
@@ -173,32 +164,31 @@ HKD_Model CreateModelFromBrushes(const std::vector<Brush>& brushes) {
     model.type = HKD_MODEL_TYPE_STATIC;
     model.tris.resize(totalTris);
     size_t triOffset = 0;
-    for (auto & [ textureName, mapPolys ] : texName2polygons) {
+    for ( auto& [ textureName, mapPolys ] : texName2polygons ) {
         HKD_Mesh mesh{};
-        mesh.isTextured = true;
-        mesh.textureFileName = textureName + ".tga"; // FIX: Check for all formats.
-        mesh.firstTri = triOffset;
-        size_t numTris = mapPolys.size();
-        mesh.numTris = numTris;
-        std::vector<Tri> tris = CreateTrisFromMapPolys( mapPolys );
-        memcpy( model.tris.data() + triOffset, tris.data(), numTris * sizeof(Tri) );
+        mesh.isTextured       = true;
+        mesh.textureFileName  = textureName + ".tga"; // FIX: Check for all formats.
+        mesh.firstTri         = triOffset;
+        size_t numTris        = mapPolys.size();
+        mesh.numTris          = numTris;
+        std::vector<Tri> tris = CreateTrisFromMapPolys(mapPolys);
+        memcpy(model.tris.data() + triOffset, tris.data(), numTris * sizeof(Tri));
         triOffset += numTris;
         model.meshes.push_back(mesh);
     }
 
     // Brush entities start at their world pos defined in TrenchBroom.
-    model.position     = glm::vec3(0.0f); 
-    model.orientation  = glm::angleAxis(glm::radians(0.0f), glm::vec3(0.0f, 0.0f, 1.0f));
-    model.scale        = glm::vec3(1.0f);
+    model.position    = glm::vec3(0.0f);
+    model.orientation = glm::angleAxis(glm::radians(0.0f), glm::vec3(0.0f, 0.0f, 1.0f));
+    model.scale       = glm::vec3(1.0f);
 
     return model;
 }
 
-static glm::mat4 PoseToMatrix(Pose pose) 
-{
-    glm::vec3 t = glm::vec3(pose.translations.x, pose.translations.y, pose.translations.z);
+static glm::mat4 PoseToMatrix(Pose pose) {
+    glm::vec3 t    = glm::vec3(pose.translations.x, pose.translations.y, pose.translations.z);
     glm::mat4 tMat = glm::translate(glm::mat4(1.0f), t); // TODO: Change to translation
-    glm::vec3 s = glm::vec3(pose.scale.x, pose.scale.y, pose.scale.z);
+    glm::vec3 s    = glm::vec3(pose.scale.x, pose.scale.y, pose.scale.z);
     glm::mat4 sMat = glm::scale(glm::mat4(1.0f), s);
     //glm::quat r = glm::quat(pose.rotation.w, pose.rotation.x, pose.rotation.y, pose.rotation.z);
     glm::mat4 rMat = glm::toMat4(pose.rotation);
@@ -206,48 +196,46 @@ static glm::mat4 PoseToMatrix(Pose pose)
     return tMat * rMat * sMat;
 }
 
-static glm::mat4 InterpolatePoses(Pose a, Pose b, float pct) 
-{
+static glm::mat4 InterpolatePoses(Pose a, Pose b, float pct) {
     glm::vec3 interpTrans = (1.0f - pct) * a.translations + pct * b.translations;
-    glm::mat4 transMat = glm::translate(glm::mat4(1.0f), interpTrans);
+    glm::mat4 transMat    = glm::translate(glm::mat4(1.0f), interpTrans);
 
     glm::vec3 interpScale = (1.0f - pct) * a.scale + pct * b.scale;
-    glm::mat4 scaleMat = glm::scale(glm::mat4(1.0f), interpScale);
+    glm::mat4 scaleMat    = glm::scale(glm::mat4(1.0f), interpScale);
 
     glm::quat interpRot = glm::slerp(a.rotation, b.rotation, pct);
-    glm::mat4 rotMat = glm::toMat4(interpRot);
+    glm::mat4 rotMat    = glm::toMat4(interpRot);
 
-    return transMat * rotMat * scaleMat;    
+    return transMat * rotMat * scaleMat;
 }
 
-void UpdateModel(HKD_Model* model, float dt)
-{
-    if (model->type == HKD_MODEL_TYPE_ANIMATED) {
+void UpdateModel(HKD_Model* model, float dt) {
+    if ( model->type == HKD_MODEL_TYPE_ANIMATED ) {
         uint32_t currentFrame = model->currentFrame;
-        uint32_t animIdx = model->currentAnimIdx;
+        uint32_t animIdx      = model->currentAnimIdx;
 
-        Anim anim = model->animations[animIdx];
+        Anim  anim       = model->animations[ animIdx ];
         float msPerFrame = 1000.0f / anim.framerate;
 
         // If the frame took really long then we need to catch up
 
-        while (dt > msPerFrame) {
+        while ( dt > msPerFrame ) {
             dt -= msPerFrame;
             currentFrame++;
             model->pctFrameDone -= msPerFrame;
         }
 
-        if (model->pctFrameDone < 0.0) {
+        if ( model->pctFrameDone < 0.0 ) {
             model->pctFrameDone = 0.0;
         }
 
-        if (dt < 0.0) {
+        if ( dt < 0.0 ) {
             dt = 0.0;
         }
 
         model->pctFrameDone += dt;
 
-        if (model->pctFrameDone > msPerFrame) {
+        if ( model->pctFrameDone > msPerFrame ) {
             currentFrame++;
             model->pctFrameDone -= msPerFrame;
         }
@@ -255,34 +243,32 @@ void UpdateModel(HKD_Model* model, float dt)
         // For now, we just cylce through all animations. If the current animations has reached its
         // end, we jump to the next animation.
 
-        if (currentFrame >= anim.firstFrame + anim.numFrames-1) {
+        if ( currentFrame >= anim.firstFrame + anim.numFrames - 1 ) {
             //model->currentAnimIdx = (model->currentAnimIdx + 1) % model->animations.size();
-            anim = model->animations[model->currentAnimIdx];
+            anim         = model->animations[ model->currentAnimIdx ];
             currentFrame = anim.firstFrame;
         }
         model->currentFrame = currentFrame;
-        uint32_t nextFrame = (currentFrame + 1) % (anim.firstFrame + anim.numFrames);
-        if (nextFrame < anim.firstFrame) {
+        uint32_t nextFrame  = (currentFrame + 1) % (anim.firstFrame + anim.numFrames);
+        if ( nextFrame < anim.firstFrame ) {
             nextFrame = anim.firstFrame;
         }
 
         //printf("currentFrame: %d\n", currentFrame);
 
-
         // Build the matrix palette
-
 
         // Build the global transform for each bone for the current pose
 
-        for (int i = 0; i < model->numJoints; i++) {
-            Pose currentPoseTransform = model->poses[currentFrame * model->numJoints + i];
-            Pose nextPoseTransform = model->poses[nextFrame * model->numJoints + i];
-            glm::mat4 poseMat = InterpolatePoses(currentPoseTransform, nextPoseTransform, model->pctFrameDone/msPerFrame);
-            if (currentPoseTransform.parent >= 0) {
-                model->palette[i] = model->palette[currentPoseTransform.parent] * poseMat;
-            }
-            else {
-                model->palette[i] = poseMat;
+        for ( int i = 0; i < model->numJoints; i++ ) {
+            Pose      currentPoseTransform = model->poses[ currentFrame * model->numJoints + i ];
+            Pose      nextPoseTransform    = model->poses[ nextFrame * model->numJoints + i ];
+            glm::mat4 poseMat
+                = InterpolatePoses(currentPoseTransform, nextPoseTransform, model->pctFrameDone / msPerFrame);
+            if ( currentPoseTransform.parent >= 0 ) {
+                model->palette[ i ] = model->palette[ currentPoseTransform.parent ] * poseMat;
+            } else {
+                model->palette[ i ] = poseMat;
             }
         }
 
@@ -290,14 +276,14 @@ void UpdateModel(HKD_Model* model, float dt)
         // the vertex from bindspace to local bonespace first and then transform the
         // vertex to the currents pose global bone space.
 
-        for (int i = 0; i < model->numJoints; i++) {
-            glm::mat4 invGlobalMat = model->invBindPoses[i];
-            model->palette[i] = model->palette[i] * invGlobalMat;
+        for ( int i = 0; i < model->numJoints; i++ ) {
+            glm::mat4 invGlobalMat = model->invBindPoses[ i ];
+            model->palette[ i ]    = model->palette[ i ] * invGlobalMat;
         }
 
         // Update Ellipsoid Collider center
         // TODO: Also entities that aren't animated should have this.
-		/*
+        /*
         EllipsoidCollider* ec = &model->ellipsoidColliders[model->currentAnimIdx];
         ec->center = model->position + glm::vec3(
             0.0f,
@@ -308,32 +294,26 @@ void UpdateModel(HKD_Model* model, float dt)
 
     // Update the rigid body
 
-    if (model->isRigidBody) {
+    if ( model->isRigidBody ) {
         UpdateRigidBodyTransform(model);
     }
 }
 
-void ApplyPhysicsToModel(HKD_Model* model)
-{
+void ApplyPhysicsToModel(HKD_Model* model) {}
 
-}
-
-void UpdateRigidBodyTransform(HKD_Model* model)
-{
+void UpdateRigidBodyTransform(HKD_Model* model) {
     model->position = model->body.m_Position;
 }
 
-glm::mat4 CreateModelMatrix(HKD_Model* model)
-{
+glm::mat4 CreateModelMatrix(HKD_Model* model) {
     glm::mat4 transMat = glm::translate(glm::mat4(1.0f), model->position);
-    glm::mat4 rotMat = glm::toMat4(model->orientation);
+    glm::mat4 rotMat   = glm::toMat4(model->orientation);
     glm::mat4 scaleMat = glm::scale(glm::mat4(1.0f), model->scale);
-    
+
     return transMat * rotMat * scaleMat;
 }
 
-glm::mat4 CreateModelMatrix(glm::vec3 pos, glm::quat orientation, glm::vec3 scale) 
-{
+glm::mat4 CreateModelMatrix(glm::vec3 pos, glm::quat orientation, glm::vec3 scale) {
     glm::mat4 T = glm::translate(glm::mat4(1.0f), pos);
     glm::mat4 R = glm::toMat4(orientation);
     glm::mat4 S = glm::scale(glm::mat4(1.0f), scale);
@@ -341,19 +321,18 @@ glm::mat4 CreateModelMatrix(glm::vec3 pos, glm::quat orientation, glm::vec3 scal
     return T * R * S;
 }
 
-void SetAnimState(HKD_Model* model, AnimState animState)
-{
+void SetAnimState(HKD_Model* model, AnimState animState) {
     AnimState currentState = (AnimState)model->currentAnimIdx;
 
-    if (currentState == animState) {
+    if ( currentState == animState ) {
         return;
     }
-    
+
     model->currentAnimIdx = (uint32_t)animState;
-    Anim anim = model->animations[model->currentAnimIdx];
-    uint32_t firstFrame = anim.firstFrame;
-    model->currentFrame = firstFrame;
-    
+    Anim     anim         = model->animations[ model->currentAnimIdx ];
+    uint32_t firstFrame   = anim.firstFrame;
+    model->currentFrame   = firstFrame;
+
     //printf("Current anim idx: %d\n", model->currentAnimIdx);
     //printf("Current frame: %d\n", model->currentFrame);
 }

--- a/r_model.h
+++ b/r_model.h
@@ -13,8 +13,8 @@
 #include "Body.h"
 #include "collision.h"
 #include "iqm_loader.h"
-#include "r_common.h"
 #include "map_parser.h"
+#include "r_common.h"
 
 enum AnimState {
     ANIM_STATE_IDLE,
@@ -24,8 +24,8 @@ enum AnimState {
 };
 
 struct HKD_Mesh {
-    uint32_t firstTri, numTris;
-    bool isTextured;
+    uint32_t    firstTri, numTris;
+    bool        isTextured;
     std::string textureFileName;
 };
 
@@ -40,29 +40,29 @@ enum HKD_ModelType {
 };
 
 struct HKD_Model {
-    HKD_ModelType type;
-    std::string filename;
-    std::vector<Tri> tris;
+    HKD_ModelType         type;
+    std::string           filename;
+    std::vector<Tri>      tris;
     std::vector<HKD_Mesh> meshes;
-    glm::vec3 position;
-    glm::quat orientation;
-    glm::vec3 scale;
-    int gpuModelHandle; // -1: Data not yet on GPU
+    glm::vec3             position;
+    glm::quat             orientation;
+    glm::vec3             scale;
+    int                   gpuModelHandle; // -1: Data not yet on GPU
     std::vector<Pose>
         poses; // A POSE IS JUST A LOCAL TRANSFORM FOR A SINGLE JOINT!!! IT IS NOT THE SKELETON STATE AT A CERTAIN FRAME!
-    uint32_t currentFrame;
-    uint32_t numFrames;
-    float pctFrameDone;
-    std::vector<glm::mat4> invBindPoses;
-    std::vector<glm::mat4> bindPoses;
-    std::vector<glm::mat4> palette;
-    uint32_t numJoints;
-    std::vector<Anim> animations;
-    std::vector<AABB> aabbs;    // one AABB for each animation (first frame of anim used).
-    std::vector<Box> aabbBoxes; // Actual vertex geometry for each aabb ready to render
+    uint32_t                       currentFrame;
+    uint32_t                       numFrames;
+    float                          pctFrameDone;
+    std::vector<glm::mat4>         invBindPoses;
+    std::vector<glm::mat4>         bindPoses;
+    std::vector<glm::mat4>         palette;
+    uint32_t                       numJoints;
+    std::vector<Anim>              animations;
+    std::vector<AABB>              aabbs;     // one AABB for each animation (first frame of anim used).
+    std::vector<Box>               aabbBoxes; // Actual vertex geometry for each aabb ready to render
     std::vector<EllipsoidCollider> ellipsoidColliders;
-    uint32_t currentAnimIdx;
-    uint32_t prevAnimIdx;
+    uint32_t                       currentAnimIdx;
+    uint32_t                       prevAnimIdx;
 
     // For drawing debugging colors. TODO: Remove later?
     glm::vec4 debugColor;
@@ -74,11 +74,11 @@ struct HKD_Model {
 
 HKD_Model CreateModelFromIQM(IQMModel* model);
 HKD_Model CreateModelFromBrushes(const std::vector<Brush>& brushes);
-void UpdateModel(HKD_Model* model, float dt);
-void ApplyPhysicsToModel(HKD_Model* model);
-void UpdateRigidBodyTransform(HKD_Model* model);
+void      UpdateModel(HKD_Model* model, float dt);
+void      ApplyPhysicsToModel(HKD_Model* model);
+void      UpdateRigidBodyTransform(HKD_Model* model);
 glm::mat4 CreateModelMatrix(HKD_Model* model);
 glm::mat4 CreateModelMatrix(glm::vec3 pos, glm::quat orientation, glm::vec3 scale);
-void SetAnimState(HKD_Model* model, AnimState animState);
+void      SetAnimState(HKD_Model* model, AnimState animState);
 
 #endif

--- a/utils/utils.cpp
+++ b/utils/utils.cpp
@@ -71,7 +71,7 @@ std::vector<std::string> SplitString(const std::string& input, char delimiter) {
 template <> float StringToFloat<float>(const char* str, char** end) {
     return std::strtof(str, end);
 }
-    
+
 template <> double StringToFloat<double>(const char* str, char** end) {
     return std::strtod(str, end);
 }

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -49,6 +49,4 @@ template <typename T> std::vector<T> ParseValues(const std::string& input) {
     return values;
 }
 
-
 #endif
-


### PR DESCRIPTION
As the title says. Apply clang format to all of our own sourcefiles.

There are instances where the formatting is a bit weird, especially when it comes to something like this:

```cpp
void CWorld::CollideEntities() {

    std::vector<BaseGameEntity*> entities = EntityManager::Instance()->Entities();
    double                       dt       = GetDeltaTime();

    // Push Touch: Entity 'bumps' into other entity.
    for ( int i = 0; i < entities.size(); i++ ) {
        BaseGameEntity* pEntity = entities[ i ];
```

The spacing is a bit odd, having so much of it between `double` and `dt`. Maybe we can turn this rule off again, however I do find this kind of formatting helpful in classes when declaring memberfunctions and variables.
Not sure if something can be done about it @benekoehler ? If not we just leave it as it is.

