### PR TITLE
Feat/enemy attack: Enemy follows player and attacks

### DIFF
--- a/CWorld.cpp
+++ b/CWorld.cpp
@@ -18,6 +18,7 @@
 #include "Audio/Audio.h"
 #include "Entity/FirstPersonPlayer/g_fp_player.h"
 #include "Entity/base_game_entity.h"
+#include "Message/g_extra_info_types.h"
 #include "Message/message_type.h"
 #include "hkd_interface.h"
 #include "irender.h"
@@ -443,8 +444,9 @@ void CWorld::RunEnemyVision()
 
                 if ( math::EllipsoidInFrustum(frustumWorld, *ec) )
                 {
-                    //Dispatcher->DispatchMessage(
-                    //    SEND_MSG_IMMEDIATELY, pEnemy->ID(), pEnemy->ID(), message_type::Collision, 0);
+                    InViewInfo inViewInfo = { pOther };
+                    Dispatcher->DispatchMessage(
+                        SEND_MSG_IMMEDIATELY, pEnemy->ID(), pEnemy->ID(), message_type::EntityInView, &inViewInfo);
                 }
             }
         }

--- a/CWorld.cpp
+++ b/CWorld.cpp
@@ -373,32 +373,38 @@ void CWorld::CollideEntities()
         {
 
             BaseGameEntity* pOther = entities[ j ];
+
             if ( pOther->ID() == pEntity->ID() )
             { // Don't collide with itself.
                 continue;
             }
 
+            EllipsoidCollider* ec = pEntity->GetEllipsoidColliderPtr();
+            if ( ec == nullptr ) // we nned an ellipsoid collider to collide with something
+            {
+                continue;
+            }
+
+            CollisionInfo ci{};
+
             if ( pOther->Type() == ET_DOOR )
             {
-                Door*              pDoor = (Door*)pOther;
-                EllipsoidCollider* ec    = pEntity->GetEllipsoidColliderPtr();
+                Door* pDoor = (Door*)pOther;
 
-                if ( ec == nullptr )
-                {
-                    continue;
-                }
+                ci = PushTouch(*ec,
+                               (float)DOD_FIXED_UPDATE_TIME / 1000.0f * pEntity->m_Velocity,
+                               pDoor->MapTris().data(),
+                               pDoor->MapTris().size());
+            }
+            else
+            {
+            }
 
-                CollisionInfo ci = PushTouch(*ec,
-                                             (float)DOD_FIXED_UPDATE_TIME / 1000.0f * pEntity->m_Velocity,
-                                             pDoor->MapTris().data(),
-                                             pDoor->MapTris().size());
-
-                if ( ci.didCollide )
-                {
-                    printf("COLLIDED!\n");
-                    Dispatcher->DispatchMessage(
-                        SEND_MSG_IMMEDIATELY, pEntity->ID(), pDoor->ID(), message_type::Collision, 0);
-                }
+            if ( ci.didCollide )
+            {
+                printf("COLLIDED!\n");
+                Dispatcher->DispatchMessage(
+                    SEND_MSG_IMMEDIATELY, pEntity->ID(), pOther->ID(), message_type::Collision, 0);
             }
         }
     }

--- a/CWorld.cpp
+++ b/CWorld.cpp
@@ -219,6 +219,8 @@ void CWorld::InitWorld(const std::string& mapName)
                             pPathCopy->SetCurrentWaypoint(enemy->m_Target);
                             pPathCopy->SetNextWaypoint(point.target);
                             enemy->SetPatrolPath(pPathCopy);
+                            Dispatcher->DispatchMessage(
+                                SEND_MSG_IMMEDIATELY, enemy->ID(), enemy->ID(), message_type::SetPatrol, 0);
                         }
                     }
                 }

--- a/CWorld.cpp
+++ b/CWorld.cpp
@@ -410,9 +410,10 @@ void CWorld::CollideEntities()
                 glm::vec3 otherCenter = pOther->GetEllipsoidColliderPtr()->center;
                 glm::vec3 selfCenter  = pEntity->GetEllipsoidColliderPtr()->center;
 
-                glm::vec3 selfToTarget = otherCenter - selfCenter;
+                glm::vec3 selfToTarget = otherCenter - selfCenter;                
                 float     distance     = glm::length(selfToTarget);
-                if ( distance < (otherRadius + selfRadius) )
+                float     bias         = distance * 0.5f; // TODO: This should not be here but in gameplay defined logic.
+                if ( (distance-bias) < (otherRadius + selfRadius) )
                 {
                     ci.didCollide = true;
                 }

--- a/Entity/Enemy/g_enemy.cpp
+++ b/Entity/Enemy/g_enemy.cpp
@@ -61,10 +61,15 @@ void Enemy::PreCollisionUpdate()
     float     dt           = (float)GetDeltaTime();
     glm::vec3 force        = m_pSteeringBehaviour->Calculate();
     glm::vec3 acceleration = force / m_Mass;
+
+    // NOTE: There is no dynamic movement happening as it didn't
+    // play nicely with slopes and it was hard to control
+    // the speed behaviour.
+    //
     //update velocity
-    //m_Velocity += acceleration * 1000.0f;
-    //m_Velocity += acceleration * dt / 1000.0f;
+    //m_Velocity += acceleration;
     //m_Velocity = math::TruncateVec3(m_Velocity, m_MaxSpeed);
+
     m_Velocity = force;
     if ( Speed() > 0.001 )
     {

--- a/Entity/Enemy/g_enemy.cpp
+++ b/Entity/Enemy/g_enemy.cpp
@@ -34,7 +34,8 @@ Enemy::Enemy(const std::vector<Property>& properties)
     // FIX: Mem Leak on exit if target is not being set.
     BaseGameEntity::GetProperty<std::string>(properties, "target", &m_Target);
 
-    LoadModel("models/multiple_anims/multiple_anims.iqm", m_Position);
+    //LoadModel("models/multiple_anims/multiple_anims.iqm", m_Position);
+    LoadModel("models/mayan_undead_warrior/mayan_undead_warrior_idle.iqm", m_Position);
     m_Model.pOwner       = this;
     m_Velocity           = glm::vec3(0.0f, 0.0f, 0.0f);
     m_PrevPosition       = GetEllipsoidColliderPtr()->center;

--- a/Entity/Enemy/g_enemy.cpp
+++ b/Entity/Enemy/g_enemy.cpp
@@ -120,6 +120,7 @@ void Enemy::PostCollisionUpdate()
     SetAnimState(&m_Model, m_AnimationState);
     UpdateModel(&m_Model, (float)dt);
 
+    /*
     if ( GetDebugSettings()->patrol )
     {
         if ( m_pPath != nullptr && !m_Target.empty() )
@@ -135,6 +136,7 @@ void Enemy::PostCollisionUpdate()
     {
         this->Idle();
     }
+    */
 }
 
 void Enemy::LoadModel(const char* path, glm::vec3 initialPosition)

--- a/Entity/Enemy/g_enemy.cpp
+++ b/Entity/Enemy/g_enemy.cpp
@@ -1,4 +1,4 @@
-//
+//enem
 // Created by benek on 10/14/24.
 //
 
@@ -58,17 +58,16 @@ Enemy::Enemy(const std::vector<Property>& properties)
 
 void Enemy::PreCollisionUpdate()
 {
-
     float     dt           = (float)GetDeltaTime();
     glm::vec3 force        = m_pSteeringBehaviour->Calculate();
     glm::vec3 acceleration = force / m_Mass;
     //update velocity
     //m_Velocity += acceleration * 1000.0f;
-    m_Velocity += acceleration * dt / 1000.0f;
-    m_Velocity = math::TruncateVec3(m_Velocity, m_MaxSpeed);
+    //m_Velocity += acceleration * dt / 1000.0f;
+    //m_Velocity = math::TruncateVec3(m_Velocity, m_MaxSpeed);
+    m_Velocity = force;
     if ( Speed() > 0.001 )
     {
-
         // Calculate the new forward direction
         glm::vec3 newForward = glm::normalize(m_Velocity);
 
@@ -99,12 +98,13 @@ void Enemy::PreCollisionUpdate()
         m_AnimationState = ANIM_STATE_WALK;
         Audio::m_Soloud.setRelativePlaySpeed(m_FootstepsHandle, 0.6f);
         Audio::m_Soloud.setVolume(m_FootstepsHandle, m_SfxFootsteps->mVolume * 0.4f);
-    }
-    else if ( Speed() > m_MaxSpeed * 0.5f )
-    { // FIXME: will this condition ever happen
-        m_AnimationState = ANIM_STATE_RUN;
-        Audio::m_Soloud.setRelativePlaySpeed(m_FootstepsHandle, 0.9f); // adjust sample speed to better match animation
-        Audio::m_Soloud.setVolume(m_FootstepsHandle, m_SfxFootsteps->mVolume);
+        if ( Speed() > m_MaxSpeed * 0.5f )
+        { // FIXME: will this condition ever happen
+            m_AnimationState = ANIM_STATE_RUN;
+            Audio::m_Soloud.setRelativePlaySpeed(m_FootstepsHandle,
+                                                 0.9f); // adjust sample speed to better match animation
+            Audio::m_Soloud.setVolume(m_FootstepsHandle, m_SfxFootsteps->mVolume);
+        }
     }
     else
     {

--- a/Entity/Enemy/g_enemy.cpp
+++ b/Entity/Enemy/g_enemy.cpp
@@ -35,7 +35,7 @@ Enemy::Enemy(const std::vector<Property>& properties)
     BaseGameEntity::GetProperty<std::string>(properties, "target", &m_Target);
 
     //LoadModel("models/multiple_anims/multiple_anims.iqm", m_Position);
-    LoadModel("models/mayan_undead_warrior/mayan_undead_warrior_idle.iqm", m_Position);
+    LoadModel("models/mayan_undead_warrior/mayan_undead_warrior_final.iqm", m_Position);
     m_Model.pOwner       = this;
     m_Velocity           = glm::vec3(0.0f, 0.0f, 0.0f);
     m_PrevPosition       = GetEllipsoidColliderPtr()->center;
@@ -50,6 +50,7 @@ Enemy::Enemy(const std::vector<Property>& properties)
     m_Near         = 0.1f;
     m_Far          = 500.0f;
 
+    // Set initial orientation in the world
     m_Orientation = glm::angleAxis(glm::radians(80.0f), DOD_WORLD_UP);
     m_Forward     = glm::rotate(m_Orientation, DOD_WORLD_FORWARD);
 
@@ -101,12 +102,12 @@ void Enemy::PreCollisionUpdate()
 
     if ( Speed() >= 0.00001f )
     {
-        m_AnimationState = ANIM_STATE_WALK;
+        //m_AnimationState = ANIM_STATE_WALK;
         Audio::m_Soloud.setRelativePlaySpeed(m_FootstepsHandle, 0.6f);
         Audio::m_Soloud.setVolume(m_FootstepsHandle, m_SfxFootsteps->mVolume * 0.4f);
         if ( Speed() > m_MaxSpeed * 0.5f )
         { // FIXME: will this condition ever happen
-            m_AnimationState = ANIM_STATE_RUN;
+            //m_AnimationState = ANIM_STATE_RUN;
             Audio::m_Soloud.setRelativePlaySpeed(m_FootstepsHandle,
                                                  0.9f); // adjust sample speed to better match animation
             Audio::m_Soloud.setVolume(m_FootstepsHandle, m_SfxFootsteps->mVolume);
@@ -114,9 +115,11 @@ void Enemy::PreCollisionUpdate()
     }
     else
     {
-        m_AnimationState = ANIM_STATE_IDLE;
+        //m_AnimationState = ANIM_STATE_IDLE;
         Audio::m_Soloud.stop(m_FootstepsHandle);
     }
+
+
 }
 
 void Enemy::PostCollisionUpdate()
@@ -154,7 +157,7 @@ void Enemy::LoadModel(const char* path, glm::vec3 initialPosition)
     m_Model             = CreateModelFromIQM(&iqmModel);
     m_Model.isRigidBody = false;
     m_Model.renderFlags = MODEL_RENDER_FLAG_NONE;
-    m_Model.scale       = glm::vec3(22.0f);
+    m_Model.scale       = glm::vec3(1.0f);
 
     for ( int i = 0; i < m_Model.animations.size(); i++ )
     {

--- a/Entity/Enemy/g_enemy.h
+++ b/Entity/Enemy/g_enemy.h
@@ -68,7 +68,7 @@ class Enemy : public MovingEntity
         assert(m_pPath != nullptr && !m_Target.empty() && "Enemy has no path or target!");
         m_pStateMachine->ChangeState(EnemyPatrol::Instance());
     }
-d
+
     void SetPatrolPath(PatrolPath* path)
     {
         m_pPath = path;

--- a/Entity/Enemy/g_enemy.h
+++ b/Entity/Enemy/g_enemy.h
@@ -100,16 +100,16 @@ class Enemy : public MovingEntity
     float m_Near;
     float m_Far;
 
+    // FIX: Those should be components for next milestone.
+    HKD_Model   m_Model;
+    PatrolPath* m_pPath;
+
   private:
     StateMachine<Enemy>* m_pStateMachine;
     double               m_Health = 100;
 
     SoLoud::AudioSource* m_SfxFootsteps;
     SoLoud::handle       m_FootstepsHandle = 0;
-
-    // FIX: Those should be components for next milestone.
-    HKD_Model   m_Model;
-    PatrolPath* m_pPath;
 
     BaseGameEntity* m_pTargetEntity;
 

--- a/Entity/Enemy/g_enemy.h
+++ b/Entity/Enemy/g_enemy.h
@@ -77,6 +77,11 @@ class Enemy : public MovingEntity
         m_pSteeringBehaviour->SetFollowPath(m_pPath);
     }
 
+    void SetTarget(BaseGameEntity* pEntity)
+    {
+        m_pTargetEntity = pEntity;
+    }
+
   public:
     bool DecreaseHealth(double amount)
     {
@@ -105,6 +110,8 @@ class Enemy : public MovingEntity
     // FIX: Those should be components for next milestone.
     HKD_Model   m_Model;
     PatrolPath* m_pPath;
+
+    BaseGameEntity* m_pTargetEntity;
 
   private:
     AnimState m_AnimationState;

--- a/Entity/Enemy/g_enemy.h
+++ b/Entity/Enemy/g_enemy.h
@@ -106,6 +106,8 @@ class Enemy : public MovingEntity
 
     BaseGameEntity* m_pTargetEntity;
 
+    AnimState m_AnimationState;
+
   private:
     StateMachine<Enemy>* m_pStateMachine;
     double               m_Health = 100;
@@ -114,7 +116,6 @@ class Enemy : public MovingEntity
     SoLoud::handle       m_FootstepsHandle = 0;
 
   private:
-    AnimState m_AnimationState;
 
     void LoadModel(const char* path, glm::vec3 initialPosition);
     void UpdateEnemyModel();

--- a/Entity/Enemy/g_enemy.h
+++ b/Entity/Enemy/g_enemy.h
@@ -104,14 +104,14 @@ class Enemy : public MovingEntity
     HKD_Model   m_Model;
     PatrolPath* m_pPath;
 
+    BaseGameEntity* m_pTargetEntity;
+
   private:
     StateMachine<Enemy>* m_pStateMachine;
     double               m_Health = 100;
 
     SoLoud::AudioSource* m_SfxFootsteps;
     SoLoud::handle       m_FootstepsHandle = 0;
-
-    BaseGameEntity* m_pTargetEntity;
 
   private:
     AnimState m_AnimationState;

--- a/Entity/Enemy/g_enemy.h
+++ b/Entity/Enemy/g_enemy.h
@@ -68,7 +68,7 @@ class Enemy : public MovingEntity
         assert(m_pPath != nullptr && !m_Target.empty() && "Enemy has no path or target!");
         m_pStateMachine->ChangeState(EnemyPatrol::Instance());
     }
-
+d
     void SetPatrolPath(PatrolPath* path)
     {
         m_pPath = path;

--- a/Entity/Enemy/g_enemy_states.cpp
+++ b/Entity/Enemy/g_enemy_states.cpp
@@ -255,6 +255,8 @@ EnemyFollow* EnemyFollow::Instance()
 void EnemyFollow::Enter(Enemy* pEnemy)
 {
     printf("Enemy entered Follow State\n");
+    pEnemy->m_pSteeringBehaviour->SetTargetAgent(pEnemy->m_pTargetEntity);
+    pEnemy->m_pSteeringBehaviour->SeekOn();
     // pEnemy->m_pSteeringBehaviour->FollowWaypointsOn();
     //pEnemy->m_pSteeringBehaviour->FollowPathOn();
 }

--- a/Entity/Enemy/g_enemy_states.cpp
+++ b/Entity/Enemy/g_enemy_states.cpp
@@ -17,7 +17,7 @@ EnemyIdle* EnemyIdle::Instance()
 
 void EnemyIdle::Enter(Enemy* pEnemy)
 {
-    //printf("Enemy entered Idle State\n");
+    printf("Enemy entered Idle State\n");
 }
 
 void EnemyIdle::Execute(Enemy* pEnemy)
@@ -27,7 +27,7 @@ void EnemyIdle::Execute(Enemy* pEnemy)
 
 void EnemyIdle::Exit(Enemy* pEnemy)
 {
-    //printf("Enemy is exiting Idle State\n");
+    printf("Enemy is exiting Idle State\n");
 }
 
 bool EnemyIdle::OnMessage(Enemy* agent, const Telegram& telegram)
@@ -263,6 +263,22 @@ void EnemyFollow::Enter(Enemy* pEnemy)
 
 void EnemyFollow::Execute(Enemy* pEnemy)
 {
+    BaseGameEntity* pOther      = pEnemy->m_pTargetEntity;
+    float           otherRadius = pOther->GetEllipsoidColliderPtr()->radiusA;
+    float           selfRadius  = pEnemy->GetEllipsoidColliderPtr()->radiusA;
+    glm::vec3       otherCenter = pOther->GetEllipsoidColliderPtr()->center;
+    glm::vec3       selfCenter  = pEnemy->GetEllipsoidColliderPtr()->center;
+
+    glm::vec3 selfToTarget = otherCenter - selfCenter;
+    float     distance     = glm::length(selfToTarget);
+    printf("distance to player: %f\n", distance);
+
+    if ( distance < (otherRadius + selfRadius) )
+    {
+        pEnemy->m_pSteeringBehaviour->SeekOff();
+        pEnemy->m_pSteeringBehaviour->NoneOn();
+        pEnemy->GetFSM()->ChangeState(EnemyIdle::Instance());
+    }
     //printf("Enemy is executing Patrol State\n");
 }
 

--- a/Entity/Enemy/g_enemy_states.cpp
+++ b/Entity/Enemy/g_enemy_states.cpp
@@ -64,6 +64,19 @@ bool EnemyIdle::OnMessage(Enemy* agent, const Telegram& telegram)
     }
     break;
 
+    case message_type::SetPatrol:
+    {
+
+        if ( agent->m_pPath != nullptr && !agent->m_Target.empty() )
+        {
+
+            agent->GetFSM()->ChangeState(EnemyPatrol::Instance());
+            return true;
+        }
+        return false;
+    }
+    break;
+
     default:
     {
         return false;
@@ -208,7 +221,7 @@ void EnemyPatrol::Exit(Enemy* pEnemy)
 
 bool EnemyPatrol::OnMessage(Enemy* agent, const Telegram& telegram)
 {
-    printf("\nEnemy received telegram %s\n", MessageToString(telegram.Message).c_str());
+    //printf("\nEnemy received telegram %s\n", MessageToString(telegram.Message).c_str());
     switch ( telegram.Message )
     {
     case message_type::EntityInView:

--- a/Entity/Enemy/g_enemy_states.cpp
+++ b/Entity/Enemy/g_enemy_states.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "g_enemy_states.h"
+#include "../../Message/g_extra_info_types.h"
 #include "../../Message/message_type.h"
 #include "g_enemy.h"
 #include <stdio.h>
@@ -207,5 +208,64 @@ void EnemyPatrol::Exit(Enemy* pEnemy)
 
 bool EnemyPatrol::OnMessage(Enemy* agent, const Telegram& telegram)
 {
+    printf("\nEnemy received telegram %s\n", MessageToString(telegram.Message).c_str());
+    switch ( telegram.Message )
+    {
+    case message_type::EntityInView:
+    {
+        //agent->DecreaseHealth(*(double*)telegram.ExtraInfo);
+        InViewInfo inViewInfo = DereferenceToType<InViewInfo>(telegram.ExtraInfo);
+        agent->SetTarget(inViewInfo.pOther);
+        agent->GetFSM()->ChangeState(EnemyFollow::Instance());
+
+        return true;
+    }
+    default:
+        return false;
+    }
+
+    return false;
+}
+
+// ---------------------------------
+//
+// Follow state
+//
+// ---------------------------------
+EnemyFollow* EnemyFollow::Instance()
+{
+    static EnemyFollow instance;
+
+    return &instance;
+}
+
+void EnemyFollow::Enter(Enemy* pEnemy)
+{
+    printf("Enemy entered Follow State\n");
+    // pEnemy->m_pSteeringBehaviour->FollowWaypointsOn();
+    //pEnemy->m_pSteeringBehaviour->FollowPathOn();
+}
+
+void EnemyFollow::Execute(Enemy* pEnemy)
+{
+    //printf("Enemy is executing Patrol State\n");
+}
+
+void EnemyFollow::Exit(Enemy* pEnemy)
+{
+    printf("Player is exiting Follow State\n");
+    //pEnemy->m_pSteeringBehaviour->FollowPathOff();
+    //pEnemy->m_pSteeringBehaviour->FollowWaypointsOff();
+}
+
+bool EnemyFollow::OnMessage(Enemy* agent, const Telegram& telegram)
+{
+    //printf("\nEnemy received telegram %s\n", MessageToString(telegram.Message).c_str());
+    switch ( telegram.Message )
+    {
+    default:
+        return false;
+    }
+
     return false;
 }

--- a/Entity/Enemy/g_enemy_states.cpp
+++ b/Entity/Enemy/g_enemy_states.cpp
@@ -32,7 +32,8 @@ static inline bool ReactToRayHit(Enemy* agent, BaseGameEntity* pSender)
             newForward.z                    = 0;
             newForward                      = glm::normalize(newForward);
             float     absOrientationAngle   = glm::orientedAngle(DOD_WORLD_FORWARD, newForward, DOD_WORLD_UP);
-            glm::quat newForwardOrientation = glm::angleAxis(absOrientationAngle, DOD_WORLD_UP);
+            float     randAngleBias         = RandBetween(-30.0f, 30.0f);
+            glm::quat newForwardOrientation = glm::angleAxis(absOrientationAngle + glm::radians(randAngleBias), DOD_WORLD_UP);
             agent->m_Orientation            = newForwardOrientation;
 
             agent->GetFSM()->ChangeState(EnemyDead::Instance());

--- a/Entity/Enemy/g_enemy_states.cpp
+++ b/Entity/Enemy/g_enemy_states.cpp
@@ -3,11 +3,55 @@
 //
 
 #include "g_enemy_states.h"
+
+#include <stdio.h>
+
+#define GLM_FORCE_RADIANS
+#include "../../dependencies/glm/ext.hpp"
+#include "../../dependencies/glm/glm.hpp"
+#include "../../dependencies/glm/gtx/quaternion.hpp"
+#include "../../dependencies/glm/gtx/vector_angle.hpp"
+
 #include "../../Message/g_extra_info_types.h"
 #include "../../Message/message_type.h"
+#include "../../Message/message_dispatcher.h"
 #include "../entity_manager.h"
 #include "g_enemy.h"
-#include <stdio.h>
+
+static inline bool ReactToRayHit(Enemy* agent, BaseGameEntity* pSender)
+{    
+    if ( pSender->Type() == ET_PLAYER )
+    {
+        agent->DecreaseHealth(100.0f);
+        if ( agent->IsDead() )
+        {
+            // Turn agent towards its shooter
+            // TODO: This code is redundant as somewhere else something like this has to be done as well.
+            // So make it a member function like 'LookAt' or something like that.
+            glm::vec3 newForward            = pSender->m_Position - agent->m_Position;
+            newForward.z                    = 0;
+            newForward                      = glm::normalize(newForward);
+            float     absOrientationAngle   = glm::orientedAngle(DOD_WORLD_FORWARD, newForward, DOD_WORLD_UP);
+            glm::quat newForwardOrientation = glm::angleAxis(absOrientationAngle, DOD_WORLD_UP);
+            agent->m_Orientation            = newForwardOrientation;
+
+            agent->GetFSM()->ChangeState(EnemyDead::Instance());
+        }
+    }
+
+    return true;
+}
+
+static inline bool ReactToInViewMessage(Enemy* pAgent, InViewInfo inViewInfo)
+{
+    if ( inViewInfo.pOther->Type() == ET_PLAYER )
+    {
+        pAgent->SetTarget(inViewInfo.pOther);
+        pAgent->GetFSM()->ChangeState(EnemyFollow::Instance());
+    }
+
+    return true;
+}
 
 EnemyIdle* EnemyIdle::Instance()
 {
@@ -18,6 +62,7 @@ EnemyIdle* EnemyIdle::Instance()
 
 void EnemyIdle::Enter(Enemy* pEnemy)
 {
+    pEnemy->m_AnimationState = ANIM_STATE_IDLE;
     printf("Enemy entered Idle State\n");
 }
 
@@ -52,16 +97,16 @@ bool EnemyIdle::OnMessage(Enemy* agent, const Telegram& telegram)
     }
     break;
 
+    case message_type::EntityInView:
+    {
+        InViewInfo inViewInfo = DereferenceToType<InViewInfo>(telegram.ExtraInfo);
+        return ReactToInViewMessage(agent, inViewInfo);
+    }
+
     case message_type::RayHit:
     {
-        agent->DecreaseHealth(20.0f);
-        if ( agent->IsDead() )
-        {
-            agent->GetFSM()->ChangeState(EnemyDead::Instance());
-            return true;
-        }
-
-        return true;
+        BaseGameEntity* pSender = EntityManager::Instance()->GetEntityFromID(telegram.Sender);
+        return ReactToRayHit(agent, pSender);
     }
     break;
 
@@ -95,11 +140,35 @@ EnemyAttacking* EnemyAttacking::Instance()
 void EnemyAttacking::Enter(Enemy* pEnemy)
 {
     //printf("Enemy entered Attacking State\n");
+    pEnemy->m_AnimationState = ANIM_STATE_ATTACK;
+ 
 }
 
 void EnemyAttacking::Execute(Enemy* pEnemy)
 {
-    //printf("Enemy is executing Attacking State\n");
+    BaseGameEntity* pOther = pEnemy->m_pTargetEntity;
+    if ( pOther == nullptr )
+    {
+        return;
+    }
+
+    // Check if still close enough to attack
+    float     otherRadius = pOther->GetEllipsoidColliderPtr()->radiusA;
+    float     selfRadius  = pEnemy->GetEllipsoidColliderPtr()->radiusA;
+    glm::vec3 otherCenter = pOther->GetEllipsoidColliderPtr()->center;
+    glm::vec3 selfCenter  = pEnemy->GetEllipsoidColliderPtr()->center;
+
+    glm::vec3 selfToTarget = otherCenter - selfCenter;
+    float     distance     = glm::length(selfToTarget);
+    float     bias         = distance * 0.5f;
+    if ( (distance - bias) < (otherRadius + selfRadius) ) // OK, close enough. Deal damage.
+    {
+        Dispatcher->DispatchMessage(SEND_MSG_IMMEDIATELY, pEnemy->ID(), pOther->ID(), message_type::Hit, nullptr);
+    }
+    else // Other entity is too far away, follow it.
+    {
+        pEnemy->GetFSM()->ChangeState(EnemyFollow::Instance());
+    }
 }
 
 void EnemyAttacking::Exit(Enemy* pEnemy)
@@ -112,18 +181,14 @@ bool EnemyAttacking::OnMessage(Enemy* agent, const Telegram& telegram)
     printf("\nEnemy received telegram %s\n", MessageToString(telegram.Message).c_str());
     switch ( telegram.Message )
     {
-    case message_type::Attack:
+
+    case message_type::RayHit:
     {
-        agent->DecreaseHealth(*(double*)telegram.ExtraInfo);
-
-        if ( agent->IsDead() )
-        {
-            agent->GetFSM()->ChangeState(EnemyDead::Instance());
-            return true;
-        }
-
-        return true;
+        BaseGameEntity* pSender = EntityManager::Instance()->GetEntityFromID(telegram.Sender);
+        return ReactToRayHit(agent, pSender);
     }
+    break;
+
     default:
         return false;
     }
@@ -138,6 +203,12 @@ EnemyDead* EnemyDead::Instance()
 void EnemyDead::Enter(Enemy* pEnemy)
 {
     printf("Enemy entered Dead State\n");
+
+    // Make sure to turn steering off for dead bodies
+    pEnemy->m_pSteeringBehaviour->SeekOff();
+    pEnemy->m_pSteeringBehaviour->NoneOn();
+
+    pEnemy->m_AnimationState = ANIM_STATE_DIE;
 }
 
 void EnemyDead::Execute(Enemy* pEnemy)
@@ -204,6 +275,7 @@ EnemyPatrol* EnemyPatrol::Instance()
 void EnemyPatrol::Enter(Enemy* pEnemy)
 {
     printf("Enemy entered Patrol State\n");
+    pEnemy->m_AnimationState = ANIM_STATE_WALK;
     // pEnemy->m_pSteeringBehaviour->FollowWaypointsOn();
     pEnemy->m_pSteeringBehaviour->FollowPathOn();
 }
@@ -227,13 +299,17 @@ bool EnemyPatrol::OnMessage(Enemy* agent, const Telegram& telegram)
     {
     case message_type::EntityInView:
     {
-        //agent->DecreaseHealth(*(double*)telegram.ExtraInfo);
         InViewInfo inViewInfo = DereferenceToType<InViewInfo>(telegram.ExtraInfo);
-        agent->SetTarget(inViewInfo.pOther);
-        agent->GetFSM()->ChangeState(EnemyFollow::Instance());
-
-        return true;
+        return ReactToInViewMessage(agent, inViewInfo);
     }
+
+    case message_type::RayHit:
+    {    
+        BaseGameEntity* pSender = EntityManager::Instance()->GetEntityFromID(telegram.Sender);
+        return ReactToRayHit(agent, pSender);
+    }
+    break;
+
     default:
         return false;
     }
@@ -256,6 +332,7 @@ EnemyFollow* EnemyFollow::Instance()
 void EnemyFollow::Enter(Enemy* pEnemy)
 {
     printf("Enemy entered Follow State\n");
+    pEnemy->m_AnimationState = ANIM_STATE_RUN;
     pEnemy->m_pSteeringBehaviour->SetTargetAgent(pEnemy->m_pTargetEntity);
     pEnemy->m_pSteeringBehaviour->SeekOn();
     // pEnemy->m_pSteeringBehaviour->FollowWaypointsOn();
@@ -284,10 +361,17 @@ bool EnemyFollow::OnMessage(Enemy* agent, const Telegram& telegram)
             printf("Enemy hit player\n");
             agent->m_pSteeringBehaviour->SeekOff();
             agent->m_pSteeringBehaviour->NoneOn();
-            agent->GetFSM()->ChangeState(EnemyIdle::Instance());
+            agent->GetFSM()->ChangeState(EnemyAttacking::Instance());
             return true;
         }
         return false;
+    }
+    break;
+
+    case message_type::RayHit:
+    {
+        BaseGameEntity* pSender = EntityManager::Instance()->GetEntityFromID(telegram.Sender);
+        ReactToRayHit(agent, pSender);
     }
     break;
 

--- a/Entity/Enemy/g_enemy_states.h
+++ b/Entity/Enemy/g_enemy_states.h
@@ -9,7 +9,8 @@
 class Enemy;
 class Telegram;
 
-class EnemyIdle : public State<Enemy> {
+class EnemyIdle : public State<Enemy>
+{
   private:
     EnemyIdle() = default;
     // copy ctor and assignment should be private
@@ -29,7 +30,8 @@ class EnemyIdle : public State<Enemy> {
     bool OnMessage(Enemy* agent, const Telegram& telegram) override;
 };
 
-class EnemyAttacking : public State<Enemy> {
+class EnemyAttacking : public State<Enemy>
+{
   private:
     EnemyAttacking() = default;
     // copy ctor and assignment should be private
@@ -49,7 +51,8 @@ class EnemyAttacking : public State<Enemy> {
     bool OnMessage(Enemy* agent, const Telegram& telegram) override;
 };
 
-class EnemyDead : public State<Enemy> {
+class EnemyDead : public State<Enemy>
+{
   private:
     EnemyDead() = default;
 
@@ -71,7 +74,8 @@ class EnemyDead : public State<Enemy> {
     bool OnMessage(Enemy* agent, const Telegram& telegram) override;
 };
 
-class EnemyWander : public State<Enemy> {
+class EnemyWander : public State<Enemy>
+{
   private:
     EnemyWander() = default;
 
@@ -93,7 +97,8 @@ class EnemyWander : public State<Enemy> {
     bool OnMessage(Enemy* agent, const Telegram& telegram) override;
 };
 
-class EnemyPatrol : public State<Enemy> {
+class EnemyPatrol : public State<Enemy>
+{
   private:
     EnemyPatrol() = default;
 
@@ -115,4 +120,26 @@ class EnemyPatrol : public State<Enemy> {
     bool OnMessage(Enemy* agent, const Telegram& telegram) override;
 };
 
+class EnemyFollow : public State<Enemy>
+{
+  private:
+    EnemyFollow() = default;
+
+    // copy ctor and assignment should be private
+    EnemyFollow(const EnemyFollow&);
+    EnemyFollow& operator=(const EnemyFollow&);
+
+  public:
+    // copy ctor and assignment should be private
+    // this is a singleton
+    static EnemyFollow* Instance();
+
+    void Enter(Enemy* pEnemy) override;
+
+    void Execute(Enemy* pEnemy) override;
+
+    void Exit(Enemy* pEnemy) override;
+
+    bool OnMessage(Enemy* agent, const Telegram& telegram) override;
+};
 #endif // ENEMYSTATES_H

--- a/Entity/FirstPersonPlayer/g_fp_player.cpp
+++ b/Entity/FirstPersonPlayer/g_fp_player.cpp
@@ -33,7 +33,7 @@ FirstPersonPlayer::FirstPersonPlayer(const std::vector<Property>& properties)
     m_pStateMachine = new StateMachine(this);
     m_pStateMachine->SetCurrentState(FirstPersonPlayerIdle::Instance());
     BaseGameEntity::GetProperty<glm::vec3>(properties, "origin", &m_Position);
-    LoadModel("models/multiple_anims/multiple_anims.iqm", m_Position);
+    LoadModel("models/mayan_undead_warrior/mayan_undead_warrior.iqm", m_Position);
     m_PrevPosition = m_Position;
     //m_PrevPosition.z += GetEllipsoidColliderPtr()->radiusB;
     m_Camera = Camera(m_Position);
@@ -192,7 +192,7 @@ void FirstPersonPlayer::PostCollisionUpdate()
     //m_Position = m_Model.position;
     m_Camera.m_Pos = m_Position;
     // Adjust the camera so it is roughly at the top of the model's head.
-    m_Camera.m_Pos += glm::vec3(0.0f, 0.0f, GetEllipsoidColliderPtr()->radiusB);
+    m_Camera.m_Pos += glm::vec3(0.0f, 0.0f, GetEllipsoidColliderPtr()->radiusB) - glm::vec3(0.0f, 0.0f, 15.0f);
     //m_Camera.Pan( -100.0f * m_Camera.m_Forward );
 
     // Adjust the Weapon model
@@ -220,7 +220,7 @@ void FirstPersonPlayer::LoadModel(const char* path, glm::vec3 initialPosition)
     m_Model.pOwner = this;
     m_Model.renderFlags |= MODEL_RENDER_FLAG_IGNORE;
     m_Model.isRigidBody = false;
-    m_Model.scale       = glm::vec3(30.0f);
+    m_Model.scale       = glm::vec3(1.0f);
 
     for ( int i = 0; i < m_Model.animations.size(); i++ )
     {
@@ -444,7 +444,7 @@ HKD_Model* FirstPersonPlayer::GetModel()
 
 bool FirstPersonPlayer::HandleMessage(const Telegram& telegram)
 {
-    return m_pStateMachine->HandleMessage(telegram);
+    return m_pStateMachine->HandleMessage(telegram);    
 }
 
 void FirstPersonPlayer::HandleInput()

--- a/Entity/FirstPersonPlayer/g_fp_player_states.cpp
+++ b/Entity/FirstPersonPlayer/g_fp_player_states.cpp
@@ -28,7 +28,24 @@ void FirstPersonPlayerIdle::Exit(FirstPersonPlayer* pPlayer) {
 }
 
 bool FirstPersonPlayerIdle::OnMessage(FirstPersonPlayer* agent, const Telegram& telegram) {
-    return false;
+    switch ( telegram.Message )
+    {
+
+    case message_type::Hit:
+    {
+        BaseGameEntity* pSender = EntityManager::Instance()->GetEntityFromID(telegram.Sender);
+        printf("Hit by enemy!\n");
+        // TODO: Implement.
+        // - before enemy sends this message it must check if its cooldown is to 0.
+        // otherwise it will spam this message.
+        return true;
+    }
+    break;
+
+    default:
+        return false;
+    }
+    
 }
 
 FirstPersonPlayerRunning* FirstPersonPlayerRunning::Instance() {

--- a/Entity/moving_entity.h
+++ b/Entity/moving_entity.h
@@ -14,7 +14,8 @@
 
 #include "../globals.h"
 
-class MovingEntity : public BaseGameEntity {
+class MovingEntity : public BaseGameEntity
+{
 
   public:
     MovingEntity(EntityType type)
@@ -23,19 +24,22 @@ class MovingEntity : public BaseGameEntity {
           m_Side(DOD_WORLD_RIGHT),
           m_Up(DOD_WORLD_UP),
           m_Mass(1.0f),
-          m_MaxSpeed(100.0f),
+          m_MaxSpeed(350.0f),
           m_MaxForce(200.5f),
           m_MaxTurnRate(1.0f) {};
 
     virtual ~MovingEntity() = default;
 
-    bool IsSpeedMaxedOut() const {
+    bool IsSpeedMaxedOut() const
+    {
         return glm::pow(m_MaxSpeed, 2) >= glm::pow(glm::length(m_Velocity), 2);
     }
-    float Speed() const {
+    float Speed() const
+    {
         return glm::length(m_Velocity);
     }
-    float SpeedSq() const {
+    float SpeedSq() const
+    {
         return glm::pow(glm::length(m_Velocity), 2);
     }
 

--- a/Entity/moving_entity.h
+++ b/Entity/moving_entity.h
@@ -24,8 +24,8 @@ class MovingEntity : public BaseGameEntity
           m_Side(DOD_WORLD_RIGHT),
           m_Up(DOD_WORLD_UP),
           m_Mass(1.0f),
-          m_MaxSpeed(350.0f),
-          m_MaxForce(200.5f),
+          m_MaxSpeed(250.0f),
+          m_MaxForce(500.5f),
           m_MaxTurnRate(1.0f) {};
 
     virtual ~MovingEntity() = default;

--- a/Entity/steering_behaviour.cpp
+++ b/Entity/steering_behaviour.cpp
@@ -122,7 +122,12 @@ glm::vec3 SteeringBehaviour::Seek(glm::vec3 targetPosition)
 {
     glm::vec3 desiredVelocity = glm::normalize(targetPosition - m_pEntity->m_Position) * m_pEntity->m_MaxSpeed;
 
+    // HACK: This just doesn't playe nicely with slopes, unfortunately.
+    // So we don't return a delta vector for now but the actual desired
+    // velocity.
+    //
     //return (desiredVelocity - m_pEntity->m_Velocity);
+
     return desiredVelocity;
 }
 
@@ -183,7 +188,8 @@ glm::vec3 SteeringBehaviour::Arrive(glm::vec3 targetPosition, Deceleration decel
 
 glm::vec3 SteeringBehaviour::FollowPath(PatrolPath* path)
 {
-    if ( path->IsEndOfSegmentReached(m_pEntity->m_Position) )
+    // HACK: Just target the current (active) waypoint
+    if ( path->IsCurrentWaypointReached(m_pEntity->m_Position) )
     {
         printf("\n\n current waypoint reached\n\n");
         path->TargetNextWaypoint();
@@ -217,7 +223,8 @@ glm::vec3 SteeringBehaviour::FollowPath(PatrolPath* path)
         target = segmentEnd;
     }
 
-    glm::vec3 force = 0.3f * Seek(target);
+    // HACK: Directly go to the next waypoint.
+    glm::vec3 force = 0.3f * Seek(segmentStart);
     force.z         = 0.0f;
     return force;
 }

--- a/Entity/steering_behaviour.cpp
+++ b/Entity/steering_behaviour.cpp
@@ -14,7 +14,7 @@ SteeringBehaviour::SteeringBehaviour(MovingEntity* pEntity)
       m_WeightFlee(1.0f),
       m_WeightArrive(1.0f),
       m_WeightFollowPath(1.0f),
-      m_WeightFollowWaypoints(1.5f),
+      m_WeightFollowWaypoints(1.0f),
       m_Deceleration(normal),
       m_WanderDistance(16.0f),
       m_WanderJitter(0.0f),
@@ -54,7 +54,7 @@ glm::vec3 SteeringBehaviour::CalculateWeightedSum()
 
     if ( On(follow_waypoints) )
     {
-        printf("FOLLOWING WAYPOINTS\n");
+        //printf("FOLLOWING WAYPOINTS\n");
         if ( m_pPath != nullptr )
         {
             m_SteeringForce += FollowWaypoints(m_pPath) * m_WeightFollowWaypoints;
@@ -66,7 +66,7 @@ glm::vec3 SteeringBehaviour::CalculateWeightedSum()
     }
     if ( On(follow_path) )
     {
-        printf("FOLLOWING PATH\n");
+        //printf("FOLLOWING PATH\n");
         if ( m_pPath != nullptr )
         {
             m_SteeringForce += FollowPath(m_pPath) * m_WeightFollowPath;
@@ -192,7 +192,7 @@ glm::vec3 SteeringBehaviour::Arrive(glm::vec3 targetPosition, Deceleration decel
 glm::vec3 SteeringBehaviour::FollowPath(PatrolPath* path)
 {
     // HACK: Just target the current (active) waypoint
-    if ( path->IsCurrentWaypointReached(m_pEntity->m_Position) )
+    if ( path->IsEndOfSegmentReached(m_pEntity->m_Position) )
     {
         printf("\n\n current waypoint reached\n\n");
         path->TargetNextWaypoint();
@@ -226,8 +226,7 @@ glm::vec3 SteeringBehaviour::FollowPath(PatrolPath* path)
         target = segmentEnd;
     }
 
-    // HACK: Directly go to the next waypoint.
-    glm::vec3 force = 0.2f * Seek(segmentStart);
+    glm::vec3 force = 0.2f * Seek(target);
     force.z         = 0.0f;
     return force;
 }

--- a/Entity/steering_behaviour.cpp
+++ b/Entity/steering_behaviour.cpp
@@ -129,6 +129,8 @@ glm::vec3 SteeringBehaviour::Seek(glm::vec3 targetPosition)
     //
     //return (desiredVelocity - m_pEntity->m_Velocity);
 
+    desiredVelocity.z = 0.0f;
+
     return desiredVelocity;
 }
 

--- a/Entity/steering_behaviour.cpp
+++ b/Entity/steering_behaviour.cpp
@@ -54,6 +54,7 @@ glm::vec3 SteeringBehaviour::CalculateWeightedSum()
 
     if ( On(follow_waypoints) )
     {
+        printf("FOLLOWING WAYPOINTS\n");
         if ( m_pPath != nullptr )
         {
             m_SteeringForce += FollowWaypoints(m_pPath) * m_WeightFollowWaypoints;
@@ -65,6 +66,7 @@ glm::vec3 SteeringBehaviour::CalculateWeightedSum()
     }
     if ( On(follow_path) )
     {
+        printf("FOLLOWING PATH\n");
         if ( m_pPath != nullptr )
         {
             m_SteeringForce += FollowPath(m_pPath) * m_WeightFollowPath;
@@ -120,7 +122,8 @@ glm::vec3 SteeringBehaviour::Seek(glm::vec3 targetPosition)
 {
     glm::vec3 desiredVelocity = glm::normalize(targetPosition - m_pEntity->m_Position) * m_pEntity->m_MaxSpeed;
 
-    return (desiredVelocity - m_pEntity->m_Velocity);
+    //return (desiredVelocity - m_pEntity->m_Velocity);
+    return desiredVelocity;
 }
 
 //----------------------------- Flee -------------------------------------
@@ -214,7 +217,7 @@ glm::vec3 SteeringBehaviour::FollowPath(PatrolPath* path)
         target = segmentEnd;
     }
 
-    glm::vec3 force = Seek(target);
+    glm::vec3 force = 0.3f * Seek(target);
     force.z         = 0.0f;
     return force;
 }

--- a/Entity/steering_behaviour.cpp
+++ b/Entity/steering_behaviour.cpp
@@ -77,6 +77,7 @@ glm::vec3 SteeringBehaviour::CalculateWeightedSum()
         }
     }
     return math::TruncateVec3(m_SteeringForce, m_pEntity->m_MaxForce);
+    //return m_SteeringFoce;
 }
 
 //------------------------------- None -----------------------------------
@@ -224,7 +225,7 @@ glm::vec3 SteeringBehaviour::FollowPath(PatrolPath* path)
     }
 
     // HACK: Directly go to the next waypoint.
-    glm::vec3 force = 0.3f * Seek(segmentStart);
+    glm::vec3 force = 0.2f * Seek(segmentStart);
     force.z         = 0.0f;
     return force;
 }

--- a/Entity/steering_behaviour.h
+++ b/Entity/steering_behaviour.h
@@ -11,9 +11,11 @@
 #include "./base_game_entity.h"
 #include "moving_entity.h"
 
-class SteeringBehaviour {
+class SteeringBehaviour
+{
   public:
-    enum summing_method {
+    enum summing_method
+    {
         weighted_average,
         prioritized,
         dithered
@@ -22,11 +24,16 @@ class SteeringBehaviour {
   public:
     SteeringBehaviour(MovingEntity* pEntity);
     glm::vec3 Calculate();
-    void      SetTargetAgent(BaseGameEntity* pAgent) {
+
+    void SetTargetAgent(BaseGameEntity* pAgent)
+    {
         m_pTargetAgent = pAgent;
     }
-    void SetFollowPath(PatrolPath* pPath) {
-        if ( pPath == nullptr ) {
+
+    void SetFollowPath(PatrolPath* pPath)
+    {
+        if ( pPath == nullptr )
+        {
             printf("SetFollowPath: pPath is nullptr! Ignore.\n");
             return;
         }
@@ -34,65 +41,84 @@ class SteeringBehaviour {
     }
 
   public:
-    void FleeOn() {
+    void FleeOn()
+    {
         m_Flags |= flee;
     }
-    void SeekOn() {
+    void SeekOn()
+    {
         m_Flags |= seek;
     }
-    void ArriveOn() {
+    void ArriveOn()
+    {
         m_Flags |= arrive;
     }
-    void WanderOn() {
+    void WanderOn()
+    {
         m_Flags |= wander;
     }
-    void FollowPathOn() {
+    void FollowPathOn()
+    {
         m_Flags |= follow_path;
     }
-    void FollowWaypointsOn() {
+    void FollowWaypointsOn()
+    {
         m_Flags |= follow_waypoints;
     }
 
-    void FleeOff() {
+    void FleeOff()
+    {
         if ( On(flee) ) m_Flags ^= flee;
     }
-    void SeekOff() {
+    void SeekOff()
+    {
         if ( On(seek) ) m_Flags ^= seek;
     }
-    void ArriveOff() {
+    void ArriveOff()
+    {
         if ( On(arrive) ) m_Flags ^= arrive;
     }
-    void WanderOff() {
+    void WanderOff()
+    {
         if ( On(wander) ) m_Flags ^= wander;
     }
-    void FollowPathOff() {
+    void FollowPathOff()
+    {
         if ( On(follow_path) ) m_Flags ^= follow_path;
     }
-    void FollowWaypointsOff() {
+    void FollowWaypointsOff()
+    {
         if ( On(follow_waypoints) ) m_Flags ^= follow_waypoints;
     }
 
-    bool isFleeOn() {
+    bool isFleeOn()
+    {
         return On(flee);
     }
-    bool isSeekOn() {
+    bool isSeekOn()
+    {
         return On(seek);
     }
-    bool isArriveOn() {
+    bool isArriveOn()
+    {
         return On(arrive);
     }
-    bool isWanderOn() {
+    bool isWanderOn()
+    {
         return On(wander);
     }
-    bool isFollowPathOn() {
+    bool isFollowPathOn()
+    {
         return On(follow_path);
     }
-    bool isFollowWaypointsOn() {
+    bool isFollowWaypointsOn()
+    {
         return On(follow_waypoints);
     }
 
   private:
-    enum behavior_type {
+    enum behavior_type
+    {
         none   = 0x00000,
         seek   = 0x00002,
         flee   = 0x00004,
@@ -148,7 +174,8 @@ class SteeringBehaviour {
 
     //Arrive makes use of these to determine how quickly a vehicle
     //should decelerate to its target
-    enum Deceleration {
+    enum Deceleration
+    {
         slow   = 1,
         normal = 2,
         fast   = 3
@@ -161,7 +188,8 @@ class SteeringBehaviour {
     summing_method m_SummingMethod;
 
     //this function tests if a specific bit of m_Flags is set
-    bool On(behavior_type behaviorType) {
+    bool On(behavior_type behaviorType)
+    {
         return (m_Flags & behaviorType) == behaviorType;
     }
 

--- a/Entity/steering_behaviour.h
+++ b/Entity/steering_behaviour.h
@@ -41,6 +41,10 @@ class SteeringBehaviour
     }
 
   public:
+    void NoneOn()
+    {
+        m_Flags = none;
+    }
     void FleeOn()
     {
         m_Flags |= flee;
@@ -91,6 +95,10 @@ class SteeringBehaviour
         if ( On(follow_waypoints) ) m_Flags ^= follow_waypoints;
     }
 
+    bool isNoneOn()
+    {
+        return m_Flags == 0;
+    }
     bool isFleeOn()
     {
         return On(flee);
@@ -205,6 +213,7 @@ class SteeringBehaviour
     glm::vec3 Arrive(glm::vec3 targetPos, Deceleration deceleration);
 
     glm::vec3 Wander();
+    glm::vec3 None();
     glm::vec3 FollowPath(PatrolPath* path);
     glm::vec3 FollowWaypoints(PatrolPath* path);
     glm::vec3 SeekPathStart(PatrolPath* path);

--- a/Message/g_extra_info_types.h
+++ b/Message/g_extra_info_types.h
@@ -1,0 +1,11 @@
+#ifndef _EXTRA_INFO_TYPES_H_
+#define _EXTRA_INFO_TYPES_H_
+
+#include "../Entity/base_game_entity.h"
+
+struct InViewInfo
+{
+    BaseGameEntity* pOther;
+};
+
+#endif

--- a/Message/message_type.h
+++ b/Message/message_type.h
@@ -11,7 +11,8 @@ enum message_type
 {
     Attack,
     Collision,
-    RayHit
+    RayHit,
+    EntityInView
 };
 
 inline std::string MessageToString(int message)
@@ -31,6 +32,11 @@ inline std::string MessageToString(int message)
     case 2:
     {
         return "RayHit";
+    }
+    break;
+    case 3:
+    {
+        return "EntityInView";
     }
     break;
 

--- a/Message/message_type.h
+++ b/Message/message_type.h
@@ -13,7 +13,8 @@ enum message_type
     Collision,
     RayHit,
     EntityInView,
-    SetPatrol
+    SetPatrol,
+    Hit
 };
 
 inline std::string MessageToString(int message)

--- a/Message/message_type.h
+++ b/Message/message_type.h
@@ -12,7 +12,8 @@ enum message_type
     Attack,
     Collision,
     RayHit,
-    EntityInView
+    EntityInView,
+    SetPatrol
 };
 
 inline std::string MessageToString(int message)

--- a/Message/message_type.h
+++ b/Message/message_type.h
@@ -40,6 +40,11 @@ inline std::string MessageToString(int message)
         return "EntityInView";
     }
     break;
+    case 4:
+    {
+        return "SetPatrol";
+    }
+    break;
 
     default:
     {

--- a/Message/telegram.h
+++ b/Message/telegram.h
@@ -8,7 +8,15 @@
 #include <math.h>
 #include <stdio.h>
 
-struct Telegram {
+#define MAX_CHARS_EXTRA_INFO 256
+
+struct ExtraInfoString
+{
+    char str[ MAX_CHARS_EXTRA_INFO ];
+};
+
+struct Telegram
+{
     // messages can be dispatched immediately or delayed for a specified amount
     // of time. If a delay is necessary this field is stamped with the time
     // the message should be dispatched.
@@ -32,16 +40,21 @@ struct Telegram {
           Sender(-1),
           Receiver(-1),
           Message(-1),
-          ExtraInfo(nullptr) {}
+          ExtraInfo(nullptr)
+    {
+    }
 
     Telegram(const double time, const int sender, const int receiver, const int msg, void* info = nullptr)
         : DispatchTime(time),
           Sender(sender),
           Receiver(receiver),
           Message(msg),
-          ExtraInfo(info) {}
+          ExtraInfo(info)
+    {
+    }
 
-    [[nodiscard]] char c_str() const {
+    [[nodiscard]] char c_str() const
+    {
         char buffer[ 100 ];
         sprintf(buffer,
                 "telegram = time: %f, Sender: %i, Receiver %i, Message: %i",
@@ -60,24 +73,29 @@ struct Telegram {
 // This is to prevent flooding an agent with identical messages.
 const double SmallestDelayInMS = 250;
 
-inline bool operator==(const Telegram& t1, const Telegram& t2) {
+inline bool operator==(const Telegram& t1, const Telegram& t2)
+{
     return (fabs(t1.DispatchTime - t2.DispatchTime) < SmallestDelayInMS) && (t1.Sender == t2.Sender)
            && (t1.Receiver == t2.Receiver) && (t1.Message == t2.Message);
 }
 
-inline bool operator<(const Telegram& t1, const Telegram& t2) {
-    if ( t1 == t2 ) {
+inline bool operator<(const Telegram& t1, const Telegram& t2)
+{
+    if ( t1 == t2 )
+    {
         return false;
     }
 
-    else {
+    else
+    {
         return (t1.DispatchTime < t2.DispatchTime);
     }
 }
 
 // handy helper function for dereferencing the ExtraInfo field of the Telegram
 // to the required type.
-template <class T> inline T DereferenceToType(void* p) {
+template <class T> inline T DereferenceToType(void* p)
+{
     return *(T*)(p);
 }
 

--- a/game.cpp
+++ b/game.cpp
@@ -240,12 +240,22 @@ bool Game::RunFrame(double dt)
     // ImGUI stuff goes into GL default FBO
 
     // ImGui::ShowDemoWindow();
+    static bool enableDebugSettings = false;
+    static int  steering            = 0;
     ImGui::Begin("DebugSettings");
-    static int steering = 0;
-    ImGui::RadioButton("enemy::patrol", &steering, 0);
-    ImGui::RadioButton("enemy::wander", &steering, 1);
-    GetDebugSettings()->patrol = steering == 0;
-    GetDebugSettings()->wander = steering == 1;
+    ImGui::Checkbox("Enable debug settings", (bool*)&enableDebugSettings);
+    if ( enableDebugSettings )
+    {
+        ImGui::RadioButton("enemy::patrol", &steering, 0);
+        ImGui::RadioButton("enemy::wander", &steering, 1);
+        GetDebugSettings()->patrol = steering == 0;
+        GetDebugSettings()->wander = steering == 1;
+    }
+    else
+    {
+        GetDebugSettings()->patrol = false;
+        GetDebugSettings()->wander = false;
+    }
     ImGui::End();
 
     ImGui::Begin("Statistics");

--- a/game.cpp
+++ b/game.cpp
@@ -74,7 +74,7 @@ void Game::Init()
 
     // Load lightmap triangles and lightmap texture
 
-    m_World->InitWorld("arena");
+    m_World->InitWorld("temple5");
     m_pPlayerEntity = m_World->PlayerEntity();
 
     // Register World Triangles at GPU.

--- a/game.cpp
+++ b/game.cpp
@@ -74,7 +74,7 @@ void Game::Init()
 
     // Load lightmap triangles and lightmap texture
 
-    m_World->InitWorld("temple5");
+    m_World->InitWorld("arena");
     m_pPlayerEntity = m_World->PlayerEntity();
 
     // Register World Triangles at GPU.

--- a/iqm_loader.cpp
+++ b/iqm_loader.cpp
@@ -276,18 +276,20 @@ IQMModel LoadIQM(const char* file) {
     for ( int i = 0; i < pHeader->numAnims; i++ ) {
         IQMAnim* pAnim = pAnims + i;
 
-        printf("Animation %d, name: %s, first frame: %d, last frame: %d, num frames: %d\n",
+        printf("Animation %d, name: %s, first frame: %d, last frame: %d, num frames: %d, loop: %d\n",
                i,
                pText + pAnim->name,
                pAnim->firstFrame,
                pAnim->firstFrame + pAnim->numFrames,
-               pAnim->numFrames);
+               pAnim->numFrames,
+               pAnim->flags & 1);
 
         Anim anim       = {};
         anim.name       = std::string(pText + pAnim->name);
         anim.firstFrame = pAnim->firstFrame;
         anim.numFrames  = pAnim->numFrames;
         anim.framerate  = pAnim->framerate;
+        anim.loop       = pAnim->flags & 1;
 
         result.animations.push_back(anim);
     }

--- a/iqm_loader.h
+++ b/iqm_loader.h
@@ -66,6 +66,7 @@ struct Anim {
     std::string name;
     uint32_t    firstFrame, numFrames;
     float       framerate;
+    bool        loop;    
 };
 
 struct Frame {

--- a/r_gl.cpp
+++ b/r_gl.cpp
@@ -304,7 +304,7 @@ bool GLRender::Init(void)
     // With sizeof(Vertex) = 92bytes => sizeof(Tri) = 276bytes we need ~ 263MB for Models.
     // A lot for a game in the 2000s! Our models have a tri count of maybe 3000 Tris (without weapon), which
     // is not even close to 1Mio tris.
-    m_ModelBatch = new GLBatch(500 * 1000);
+    m_ModelBatch = new GLBatch(1000 * 1000);
 
     // Batches but for different purposes
     m_ImPrimitiveBatch        = new GLBatch(1000);

--- a/r_gl.cpp
+++ b/r_gl.cpp
@@ -259,7 +259,7 @@ bool GLRender::Init(void)
     SDL_ShowWindow(m_Window);
 
     // GL Vsync on
-    if ( SDL_GL_SetSwapInterval(1) != 0 )
+    if ( SDL_GL_SetSwapInterval(0) != 0 )
     {
         SDL_Log("Failed to enable vsync!\n");
     }

--- a/r_gl_shader.cpp
+++ b/r_gl_shader.cpp
@@ -37,9 +37,11 @@ static GLuint   g_ViewProjUBO;
 static GLuint   g_SettingsUBO;
 static uint32_t g_SettingsBits;
 
-bool Shader::Load(const std::string& vertName, const std::string& fragName, uint32_t shaderFeatureBits) {
+bool Shader::Load(const std::string& vertName, const std::string& fragName, uint32_t shaderFeatureBits)
+{
     if ( !CompileShader(vertName, GL_VERTEX_SHADER, m_VertexShader)
-         || !CompileShader(fragName, GL_FRAGMENT_SHADER, m_FragmentShader) ) {
+         || !CompileShader(fragName, GL_FRAGMENT_SHADER, m_FragmentShader) )
+    {
 
         return false;
     }
@@ -57,7 +59,8 @@ bool Shader::Load(const std::string& vertName, const std::string& fragName, uint
     //glBindBuffer(GL_UNIFORM_BUFFER, g_ViewProjUBO);
     GLuint bindingPoint    = BIND_POINT_VIEW_PROJECTION;
     m_ViewProjUniformIndex = glGetUniformBlockIndex(m_ShaderProgram, "ViewProjMatrices");
-    if ( m_ViewProjUniformIndex == GL_INVALID_INDEX ) {
+    if ( m_ViewProjUniformIndex == GL_INVALID_INDEX )
+    {
         printf("SHADER-WARNING: Not able to get index for UBO in shader program.\nShaders:\n %s\n %s\n",
                vertName.c_str(),
                fragName.c_str());
@@ -71,7 +74,8 @@ bool Shader::Load(const std::string& vertName, const std::string& fragName, uint
     //glBindBuffer(GL_UNIFORM_BUFFER, g_SettingsUBO);
     GLuint settingsBindingPoint = BIND_POINT_SETTINGS;
     m_SettingsUniformIndex      = glGetUniformBlockIndex(m_ShaderProgram, "Settings");
-    if ( m_SettingsUniformIndex == GL_INVALID_INDEX ) {
+    if ( m_SettingsUniformIndex == GL_INVALID_INDEX )
+    {
         printf("SHADER-WARNING: Not able to get index for UBO in shader program.\nShaders:\n %s\n %s\n",
                vertName.c_str(),
                fragName.c_str());
@@ -83,13 +87,15 @@ bool Shader::Load(const std::string& vertName, const std::string& fragName, uint
 
     // TODO: Animation stuff is not global to all shaders. That is why we check for shader flags here.
 
-    if ( shaderFeatureBits & SHADER_FEATURE_MODEL_ANIMATION_BIT ) {
+    if ( shaderFeatureBits & SHADER_FEATURE_MODEL_ANIMATION_BIT )
+    {
 
         // Per frame per model animation matrix palette
         GLuint paletteBindingPoint
             = g_PaletteBindingPoint++; // If a UBO is not being shared between shaders we need separate binding points to these buffers
         m_PaletteUniformIndex = glGetUniformBlockIndex(m_ShaderProgram, "Palette");
-        if ( m_PaletteUniformIndex == GL_INVALID_INDEX ) {
+        if ( m_PaletteUniformIndex == GL_INVALID_INDEX )
+        {
             printf("SHADER-WARNING: Not able to get index for UBO in shader program.\nShaders:\n %s\n %s\n",
                    vertName.c_str(),
                    fragName.c_str());
@@ -97,6 +103,8 @@ bool Shader::Load(const std::string& vertName, const std::string& fragName, uint
         }
         glUniformBlockBinding(m_ShaderProgram, m_PaletteUniformIndex, paletteBindingPoint);
 
+        // TODO: MAKE A GOOD ERROR WHEN A MODEL HAS TOO MANY BONES AS THIS WILL BE
+        // VERY HARD TO TRACK DOWN WHY THE PROGRAM DOES SUPER WEIRD THINGS OTHERWISE.
         glGenBuffers(1, &m_PaletteUBO);
         glBindBuffer(GL_UNIFORM_BUFFER, m_PaletteUBO);
         glBufferData(GL_UNIFORM_BUFFER, MAX_BONES * sizeof(glm::mat4), nullptr, GL_DYNAMIC_DRAW);
@@ -107,12 +115,14 @@ bool Shader::Load(const std::string& vertName, const std::string& fragName, uint
     return true;
 }
 
-void Shader::InitializeSpriteUniforms() {
+void Shader::InitializeSpriteUniforms()
+{
     // TODO: (Michael): Uniform Binding happens quite often (see init shader above). Simplify this.
 
     GLuint bindingPoint  = BIND_POINT_SPRITE_DATA;
     m_SpriteUniformIndex = glGetUniformBlockIndex(m_ShaderProgram, "SpriteData");
-    if ( m_SpriteUniformIndex == GL_INVALID_INDEX ) {
+    if ( m_SpriteUniformIndex == GL_INVALID_INDEX )
+    {
         printf("Not able to bind sprite ubo!\n");
         // TODO: What to do in this case???
     }
@@ -125,12 +135,14 @@ void Shader::InitializeSpriteUniforms() {
     glBindBuffer(GL_UNIFORM_BUFFER, 0);
 }
 
-void Shader::InitializeFontUniforms() {
+void Shader::InitializeFontUniforms()
+{
     // TODO: (Michael): Uniform Binding happens quite often (see init shader above). Simplify this.
 
     GLuint bindingPoint = BIND_POINT_FONT;
     m_FontUniformIndex  = glGetUniformBlockIndex(m_ShaderProgram, "fontUB");
-    if ( m_FontUniformIndex == GL_INVALID_INDEX ) {
+    if ( m_FontUniformIndex == GL_INVALID_INDEX )
+    {
         //printf("SHADER-WARNING: Not able to get index for UBO in shader program.\nShaders:\n %s\n %s\n", vertName.c_str(), fragName.c_str());
         printf("Not able to bind fontUBO!\n");
         // TODO: What to do in this case???
@@ -144,12 +156,14 @@ void Shader::InitializeFontUniforms() {
     glBindBuffer(GL_UNIFORM_BUFFER, 0);
 }
 
-void Shader::InitializeShapesUniforms() {
+void Shader::InitializeShapesUniforms()
+{
     // TODO: (Michael): Uniform Binding happens quite often (see init shader above). Simplify this.
 
     GLuint bindingPoint  = BIND_POINT_SHAPES;
     m_ShapesUniformIndex = glGetUniformBlockIndex(m_ShaderProgram, "shapesUB");
-    if ( m_ShapesUniformIndex == GL_INVALID_INDEX ) {
+    if ( m_ShapesUniformIndex == GL_INVALID_INDEX )
+    {
         //printf("SHADER-WARNING: Not able to get index for UBO in shader program.\nShaders:\n %s\n %s\n", vertName.c_str(), fragName.c_str());
         printf("Not able to bind shapesUB! n");
         // TODO: What to do in this case???
@@ -162,50 +176,60 @@ void Shader::InitializeShapesUniforms() {
     glBindBufferRange(GL_UNIFORM_BUFFER, bindingPoint, m_ShapesUBO, 0, sizeof(ShapesUB));
     glBindBuffer(GL_UNIFORM_BUFFER, 0);
 }
-void Shader::Unload() {
+void Shader::Unload()
+{
     glDeleteProgram(m_ShaderProgram);
     glDeleteShader(m_VertexShader);
     glDeleteShader(m_FragmentShader);
 }
 
-void Shader::Activate() {
+void Shader::Activate()
+{
     glUseProgram(m_ShaderProgram);
 }
 
-GLuint Shader::Program() const {
+GLuint Shader::Program() const
+{
     return m_ShaderProgram;
 }
 
-void Shader::SetViewProjMatrices(glm::mat4 view, glm::mat4 proj) {
+void Shader::SetViewProjMatrices(glm::mat4 view, glm::mat4 proj)
+{
     glBindBuffer(GL_UNIFORM_BUFFER, g_ViewProjUBO);
     glBufferSubData(GL_UNIFORM_BUFFER, 0, sizeof(glm::mat4), glm::value_ptr(view));
     glBufferSubData(GL_UNIFORM_BUFFER, sizeof(glm::mat4), sizeof(glm::mat4), glm::value_ptr(proj));
     glBindBuffer(GL_UNIFORM_BUFFER, 0);
 }
 
-void Shader::SetMatrixPalette(glm::mat4* palette, uint32_t numMatrices) {
+void Shader::SetMatrixPalette(glm::mat4* palette, uint32_t numMatrices)
+{
     glBindBuffer(GL_UNIFORM_BUFFER, m_PaletteUBO);
     glBufferSubData(GL_UNIFORM_BUFFER, 0, numMatrices * sizeof(glm::mat4), palette);
     glBindBuffer(GL_UNIFORM_BUFFER, 0);
 }
 
-void Shader::SetMat4(std::string uniformName, glm::mat4 mat4) {
+void Shader::SetMat4(std::string uniformName, glm::mat4 mat4)
+{
     GLuint loc = glGetUniformLocation(m_ShaderProgram, uniformName.c_str());
     glUniformMatrix4fv(loc, 1, GL_FALSE, (float*)&mat4);
 }
 
-void Shader::SetVec3(std::string uniformName, glm::vec3 vec3) {
+void Shader::SetVec3(std::string uniformName, glm::vec3 vec3)
+{
     GLuint loc = glGetUniformLocation(m_ShaderProgram, uniformName.c_str());
     glUniform3fv(loc, 1, (float*)&vec3);
 }
 
-void Shader::SetVec4(std::string uniformName, glm::vec4 vec4) {
+void Shader::SetVec4(std::string uniformName, glm::vec4 vec4)
+{
     GLuint loc = glGetUniformLocation(m_ShaderProgram, uniformName.c_str());
     glUniform4fv(loc, 1, (float*)&vec4);
 }
 
-void Shader::DrawWireframe(uint32_t yesOrNo) {
-    if ( yesOrNo ) {
+void Shader::DrawWireframe(uint32_t yesOrNo)
+{
+    if ( yesOrNo )
+    {
         g_SettingsBits |= SHADER_WIREFRAME_ON_MESH;
     }
     glBindBuffer(GL_UNIFORM_BUFFER, g_SettingsUBO);
@@ -213,7 +237,8 @@ void Shader::DrawWireframe(uint32_t yesOrNo) {
     glBindBuffer(GL_UNIFORM_BUFFER, 0);
 }
 
-void Shader::SetShaderSettingBits(uint32_t bits) {
+void Shader::SetShaderSettingBits(uint32_t bits)
+{
     g_SettingsBits |= bits;
     ShaderSettings settings;
     settings.u32bitMasks.x = g_SettingsBits;
@@ -222,14 +247,16 @@ void Shader::SetShaderSettingBits(uint32_t bits) {
     glBindBuffer(GL_UNIFORM_BUFFER, 0);
 }
 
-void Shader::ResetShaderSettingBits(uint32_t bits) {
+void Shader::ResetShaderSettingBits(uint32_t bits)
+{
     g_SettingsBits = (g_SettingsBits & (~bits));
     glBindBuffer(GL_UNIFORM_BUFFER, g_SettingsUBO);
     glBufferSubData(GL_UNIFORM_BUFFER, 0, 4 * sizeof(uint32_t), (void*)&g_SettingsBits);
     glBindBuffer(GL_UNIFORM_BUFFER, 0);
 }
 
-void Shader::InitGlobalBuffers() {
+void Shader::InitGlobalBuffers()
+{
     printf("INITIALIZE GLOBAL SHADER BUFFERS...\n");
 
     // view projection matrices
@@ -247,10 +274,12 @@ void Shader::InitGlobalBuffers() {
     glBindBuffer(GL_UNIFORM_BUFFER, 0);
 }
 
-bool Shader::CompileShader(const std::string& fileName, GLenum shaderType, GLuint& outShader) {
+bool Shader::CompileShader(const std::string& fileName, GLenum shaderType, GLuint& outShader)
+{
     std::string shaderFilePath = g_GameDir + fileName;
     HKD_File    shaderCode;
-    if ( hkd_read_file(shaderFilePath.c_str(), &shaderCode) != HKD_FILE_SUCCESS ) {
+    if ( hkd_read_file(shaderFilePath.c_str(), &shaderCode) != HKD_FILE_SUCCESS )
+    {
         printf("Could not read file: %s!\n", fileName.c_str());
         return false;
     }
@@ -259,7 +288,8 @@ bool Shader::CompileShader(const std::string& fileName, GLenum shaderType, GLuin
     glShaderSource(outShader, 1, (GLchar**)(&shaderCode.data), nullptr);
     glCompileShader(outShader);
 
-    if ( !IsCompiled(outShader) ) {
+    if ( !IsCompiled(outShader) )
+    {
         printf("Failed to compile shader: %s\n", fileName.c_str());
         return false;
     }
@@ -267,10 +297,12 @@ bool Shader::CompileShader(const std::string& fileName, GLenum shaderType, GLuin
     return true;
 }
 
-bool Shader::IsCompiled(GLuint shader) {
+bool Shader::IsCompiled(GLuint shader)
+{
     GLint status;
     glGetShaderiv(shader, GL_COMPILE_STATUS, &status);
-    if ( status != GL_TRUE ) {
+    if ( status != GL_TRUE )
+    {
         char buffer[ 512 ];
         memset(buffer, 0, 512);
         glGetShaderInfoLog(shader, 511, nullptr, buffer);
@@ -282,10 +314,12 @@ bool Shader::IsCompiled(GLuint shader) {
     return true;
 }
 
-bool Shader::IsValidProgram() {
+bool Shader::IsValidProgram()
+{
     GLint status;
     glGetProgramiv(m_ShaderProgram, GL_LINK_STATUS, &status);
-    if ( status != GL_TRUE ) {
+    if ( status != GL_TRUE )
+    {
         char buffer[ 512 ];
         memset(buffer, 0, 512);
         glGetProgramInfoLog(m_ShaderProgram, 512, nullptr, buffer);

--- a/r_gl_shader.h
+++ b/r_gl_shader.h
@@ -11,20 +11,22 @@
 
 #include "r_model.h"
 
-#define MAX_BONES 96
+#define MAX_BONES 300
 
 #define SHADER_FEATURE_MODEL_ANIMATION_BIT (0x00000001)
 #define SHADER_FEATURE_MAX (0x00000001 << 1)
 
 // TODO: (Michael): Change classname to CglShader or something like that to make clear this is GL specific.
-class Shader {
+class Shader
+{
   public:
     bool   Load(const std::string& vertName, const std::string& fragName, uint32_t shaderFeatureBits = 0x0);
     void   Unload();
     void   Activate();
     GLuint Program() const;
 
-    bool operator==(const Shader& rhs) {
+    bool operator==(const Shader& rhs)
+    {
         return m_ShaderProgram == rhs.m_ShaderProgram;
     }
 

--- a/r_model.cpp
+++ b/r_model.cpp
@@ -297,19 +297,30 @@ void UpdateModel(HKD_Model* model, float dt)
 
         // For now, we just cylce through all animations. If the current animations has reached its
         // end, we jump to the next animation.
-
+        bool animationDone = false;
         if ( currentFrame >= anim.firstFrame + anim.numFrames - 1 )
         {
+            animationDone = true;
             //model->currentAnimIdx = (model->currentAnimIdx + 1) % model->animations.size();
             anim         = model->animations[ model->currentAnimIdx ];
             currentFrame = anim.firstFrame;
         }
-        model->currentFrame = currentFrame;
-        uint32_t nextFrame  = (currentFrame + 1) % (anim.firstFrame + anim.numFrames);
+        uint32_t nextFrame = (currentFrame + 1) % (anim.firstFrame + anim.numFrames);
         if ( nextFrame < anim.firstFrame )
         {
             nextFrame = anim.firstFrame;
         }
+
+        // Check if this animation has looping turned off and the animation
+        // has already played once. If so, repeat the last frame of
+        // the animation forever...
+        if ( animationDone && !anim.loop )
+        {
+            currentFrame = anim.firstFrame + anim.numFrames - 1;
+            nextFrame = currentFrame;
+        }
+        
+        model->currentFrame = currentFrame;
 
         //printf("currentFrame: %d\n", currentFrame);
 

--- a/r_model.h
+++ b/r_model.h
@@ -22,6 +22,8 @@ enum AnimState
     ANIM_STATE_IDLE,
     ANIM_STATE_WALK,
     ANIM_STATE_RUN,
+    ANIM_STATE_ATTACK,
+    ANIM_STATE_DIE,
     ANIM_STATE_NONE
 };
 
@@ -62,7 +64,7 @@ struct HKD_Model
         poses; // A POSE IS JUST A LOCAL TRANSFORM FOR A SINGLE JOINT!!! IT IS NOT THE SKELETON STATE AT A CERTAIN FRAME!
     uint32_t                       currentFrame;
     uint32_t                       numFrames;
-    float                          pctFrameDone;
+    float                          pctFrameDone;    
     std::vector<glm::mat4>         invBindPoses;
     std::vector<glm::mat4>         bindPoses;
     std::vector<glm::mat4>         palette;

--- a/utils/quick_math.cpp
+++ b/utils/quick_math.cpp
@@ -80,8 +80,8 @@ Frustum BuildFrustum(const glm::mat4& Mcam, float g, float s, float n, float f)
     Frustum frustum{};
     frustum.projDistance = g;
     frustum.aspectRatio  = s;
-    frustum.near         = n;
-    frustum.far          = f;
+    frustum.nearPlane    = n;
+    frustum.farPlane     = f;
 
     // Create vertices for near plane
     float z               = n / g;

--- a/utils/quick_math.cpp
+++ b/utils/quick_math.cpp
@@ -147,8 +147,6 @@ bool EllipsoidInFrustum(const Frustum& frustum, const EllipsoidCollider& ec)
         }
     }
 
-    printf("Ellipsoid in frustum!\n");
-
     return true;
 }
 

--- a/utils/quick_math.h
+++ b/utils/quick_math.h
@@ -11,8 +11,8 @@ struct Frustum
 {
     float projDistance;
     float aspectRatio;
-    float near;
-    float far;
+    float nearPlane;
+    float farPlane;
 
     Plane  planes[ 6 ];
     Vertex vertices[ 8 ];


### PR DESCRIPTION
When the player gets in the enemy's vision frustum, the enemy will follow the player and try to attack them when close enough.
This basically is doing what @benekoehler has done already, in fact it is from #58 . The major change is that for the enemy's field of view the vision frustum is being calculated differently. In this version it is not required for the player to be on the same z-level as the enemy.

- New enemy model is integrated. Files are on the server in `assets/models/mayan_undead_warrior`.
- Enemy attacks when close enough and follow the player again when the player moves away.
- Model's support IQM's loop flag for animations. That way the death animation will only played once.
- Fix for windows: `far` is predefined on MSVC for declaring far pointers. So the name has been changed in the frustum struct. Namespace would have worked as well but that was the faster way and is maybe more expressive anyways (`far` changed to `farPlane`).